### PR TITLE
Adding more rollout percentages

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/Constants.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/Constants.java
@@ -22,7 +22,7 @@ public class Constants {
     static final DecimalFormat PERCENTAGE_FORMATTER = new DecimalFormat("#.#");
 
     /** Allowed percentage values when doing a staged rollout to production. */
-    static final double[] ROLLOUT_PERCENTAGES = { 0.5, 1, 5, 10, 20, 50, 100 };
+    static final double[] ROLLOUT_PERCENTAGES = { 0.5, 1, 5, 10, 20, 30, 40, 50, 60, 70, 80, 90, 100 };
     static final double DEFAULT_PERCENTAGE = 100;
 
 }


### PR DESCRIPTION
Since the Google Play console supports more percentages than just `0.5, 1, 5, 10, 20, 50, 100`  adding more support percentage levels.

Technically it seems that any percentage is allowed now. Will thinking about creating another PR to remove the restriction. 