### PR TITLE
Throw NPE if response google error is null

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/PublisherApiException.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/PublisherApiException.java
@@ -29,8 +29,10 @@ public class PublisherApiException extends UploadException {
                     errors.add("The API credentials provided do not have permission to apply these changes");
                 }
             } else {
-                for (GoogleJsonError.ErrorInfo error : details.getErrors()) {
-                    errors.add(error.getMessage());
+                if (details.getErrors() != null) {
+                    for (GoogleJsonError.ErrorInfo error : details.getErrors()) {
+                        errors.add(error.getMessage());
+                    }
                 }
                 this.errorMessages = Collections.unmodifiableList(errors);
             }


### PR DESCRIPTION
java.lang.NullPointerException
	at org.jenkinsci.plugins.googleplayandroidpublisher.PublisherApiException.<init>(PublisherApiException.java:32)
	at org.jenkinsci.plugins.googleplayandroidpublisher.AbstractPublisherTask.call(AbstractPublisherTask.java:36)
	at hudson.FilePath.act(FilePath.java:1163)
	at org.jenkinsci.plugins.googleplayandroidpublisher.ApkPublisher.publishApk(ApkPublisher.java:378)
	at org.jenkinsci.plugins.googleplayandroidpublisher.ApkPublisher.perform(ApkPublisher.java:198)
	at hudson.tasks.BuildStepCompatibilityLayer.perform(BuildStepCompatibilityLayer.java:81)
	at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
	at hudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:744)
	at hudson.model.AbstractBuild$AbstractBuildExecution.performAllBuildSteps(AbstractBuild.java:690)
	at hudson.model.Build$BuildExecution.post2(Build.java:186)
	at hudson.model.AbstractBuild$AbstractBuildExecution.post(AbstractBuild.java:635)
	at hudson.model.Run.execute(Run.java:1831)
	at hudson.model.FreeStyleBuild.run(FreeStyleBuild.java:43)
	at hudson.model.ResourceController.execute(ResourceController.java:97)

