### PR TITLE
Fixed an issue where editService.apks().list()returns null if the Tra…

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
@@ -79,6 +79,10 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
 
         // Get the list of existing APKs and their info
         final List<Apk> existingApks = editService.apks().list(applicationId, editId).execute().getApks();
+	if ( existingApks == null ) {
+	    logger.println("App release track is empty!");
+	}
+	else
         for (Apk apk : existingApks) {
             existingVersionCodes.add(apk.getVersionCode());
         }
@@ -97,6 +101,7 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
             logger.println(String.format(" minSdkVersion: %s", metadata.getMinSdkVersion()));
 
             // Check whether this APK already exists on the server (i.e. uploading it would fail)
+	    if ( existingApks != null )
             for (Apk apk : existingApks) {
                 if (apk.getBinary().getSha1().toLowerCase(Locale.ENGLISH).equals(apkSha1Hash)) {
                     logger.println();


### PR DESCRIPTION
…ck of App Release is empty.

In the Google Play Console, if an APK file has been uploaded to one of the tracks of the App Release, but still in the library and not added to the track, 'editService.apks ().list()' will be null, so you need to check this.
See the attached screenshot for details.

Track is empty.
![2018-11-02 13 12 21](https://user-images.githubusercontent.com/12762399/47894066-01bd8300-dea4-11e8-8488-06273e197d8f.png)

But already update apks.
![2018-11-02 13 12 05](https://user-images.githubusercontent.com/12762399/47894088-231e6f00-dea4-11e8-8b8e-3150b2448b1e.png)
