### PR TITLE
Migrate to Android Publisher SDK v3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-androidpublisher</artifactId>
-      <version>v2-rev47-1.22.0</version>
+      <version>v3-rev42-1.22.0</version>
     </dependency>
 
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackAssignmentTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackAssignmentTask.java
@@ -1,8 +1,8 @@
 package org.jenkinsci.plugins.googleplayandroidpublisher;
 
 import com.google.api.services.androidpublisher.model.Apk;
+import com.google.api.services.androidpublisher.model.TrackRelease;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
-import hudson.model.BuildListener;
 import hudson.model.TaskListener;
 
 import java.io.IOException;
@@ -16,12 +16,12 @@ import static hudson.Util.join;
 
 class TrackAssignmentTask extends TrackPublisherTask<Boolean> {
 
-    private final Collection<Integer> versionCodes;
+    private final List<Integer> versionCodes;
 
     TrackAssignmentTask(TaskListener listener, GoogleRobotCredentials credentials, String applicationId,
                         Collection<Integer> versionCodes, ReleaseTrack track, double rolloutPercentage) {
         super(listener, credentials, applicationId, track, rolloutPercentage);
-        this.versionCodes = versionCodes;
+        this.versionCodes = new ArrayList<>(versionCodes);
     }
 
     @Override
@@ -63,7 +63,8 @@ class TrackAssignmentTask extends TrackPublisherTask<Boolean> {
         // TODO: We could be nice and detect in advance if a user attempts to downgrade
 
         // Move the version codes to the configured track
-        assignApksToTrack(versionCodes, track, rolloutFraction);
+        TrackRelease release = Util.buildRelease(versionCodes, rolloutFraction, null);
+        assignApksToTrack(versionCodes, track, rolloutFraction, release);
 
         // Commit the changes
         try {


### PR DESCRIPTION
Majority of changes are related to:
1. VersionCodes and ReleaseNotes have moved into the TrackRelease model
2. VersionCode has changed from int to long

This is a prerequisite for abstracting the Apk publisher to a more generic
"package" publisher, in order to support both APK and AAB uploads: JENKINS-53067