### PR TITLE
wrong expansion file version code

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
@@ -69,6 +69,11 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
             existingVersionCodes.add(apk.getVersionCode());
         }
 
+        if(expansionFiles != null)
+        {
+            existingVersionCodes.addAll(expansionFiles.keySet());
+        }
+
         // Upload each of the APKs
         logger.println(String.format("Uploading %d APK(s) with application ID: %s%n", apkFiles.size(), applicationId));
         final ArrayList<Integer> uploadedVersionCodes = new ArrayList<>();


### PR DESCRIPTION
Currently uploading expansion file should be considered when usePreviousExpansionFilesIfMissing = true
This fixes scenario when you trying to upload multiple apks and one expansion file attached to the lowest version apk. All others apk should inherit that expansion file and not old one from google play.