### PR TITLE
Update to Jenkins 2.138.4, and fix some remoting issues

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,12 +4,12 @@
   <parent>
     <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>3.47</version>
+    <version>3.50</version>
     <relativePath />
   </parent>
 
   <properties>
-    <jenkins.version>2.60.3</jenkins.version>
+    <jenkins.version>2.138.4</jenkins.version>
     <java.level>8</java.level>
   </properties>
 
@@ -66,11 +66,16 @@
       <version>1.19</version>
     </dependency>
 
-    <!-- Pinned as various other dependencies rely on it -->
+    <!-- Pinning these versions as various other dependencies rely on them -->
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
       <version>1.25.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-core</artifactId>
+      <version>2.9.8</version>
     </dependency>
 
     <!-- Testing -->

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,67 @@
       <version>2.28.2</version>
       <scope>test</scope>
     </dependency>
+
+    <!-- Install mock agent plugin when running locally, as it's very useful -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>mock-slave</artifactId>
+      <version>1.13</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Install Pipeline when running locally, so we can test Pipelines -->
+    <!-- Versions don't need to be supplied, as they come from the BOM below -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-basic-steps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-cps</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-durable-task-step</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jenkins-ci.plugins.workflow</groupId>
+      <artifactId>workflow-job</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Also add the Declarative Pipeline plugin, which isn't included in the BOM… -->
+    <dependency>
+      <groupId>org.jenkinsci.plugins</groupId>
+      <artifactId>pipeline-model-definition</artifactId>
+      <version>1.3.8</version>
+      <scope>test</scope>
+    </dependency>
+
+    <!-- Pinning this version as pipeline-model-definition depends on it -->
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.7</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
+  <dependencyManagement>
+    <dependencies>
+      <!-- Simplifies inclusion of plugins: https://github.com/jenkinsci/bom -->
+      <dependency>
+        <groupId>io.jenkins.tools.bom</groupId>
+        <artifactId>bom</artifactId>
+        <version>2.138.1</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/AbstractPublisherTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/AbstractPublisherTask.java
@@ -35,6 +35,8 @@ public abstract class AbstractPublisherTask<V> extends MasterToSlaveCallable<V, 
         } catch (InterruptedException e) {
             // There's no special handling we want to do if the build is interrupted, so just wrap and rethrow
             throw new UploadException(e);
+        } finally {
+            logger.flush();
         }
     }
 


### PR DESCRIPTION
Bump the minimum Jenkins version to 2.138.4, which is the minimum LTS version that Pipeline currently supports.

This also makes it possible to install the Pipeline plugins during local development, which has also been done here.

There are also some fixes to logging and the use of anonymous classes when fetching APK metadata.