### PR TITLE
Allow applying expansion files from the current upload to multiple APKs

### DIFF
--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-expansionFilesPattern.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-expansionFilesPattern.html
@@ -10,7 +10,7 @@
 
   <h2>Naming</h2>
   Files <b>must</b> be named in the format
-  <tt>[main|patch].&lt;expansion-version&gt;.&lt;application-id&gt.obb</tt>
+  <tt>[main|patch].&lt;apk-version&gt;.&lt;application-id&gt.obb</tt>
   <p/>
   For example:
   <ul>
@@ -35,8 +35,9 @@
   <p/>
   With this option enabled, if not enough expansion files are provided for all
   of the APK(s) being uploaded, this plugin will search for the <i>newest</i>,
-  previously-uploaded APKs on Google Play with main or patch expansion files,
-  and will associate those files with the new APK(s) being uploaded here.
+  APKs on Google Play with main or patch expansion files — whether previously
+  uploaded, or uploaded via the current build — and will associate those files
+  with the new APK(s) being uploaded here.
   <p/>
   For example: If you want to upload a new APK, but the expansion files have not
   changed at all, you should leave the "Expansion files" field blank, but enable
@@ -48,7 +49,12 @@
   then just provide the patch expansion file and make sure this option is
   checked. The uploaded APK will have the existing main expansion file
   associated with it, along with the newly-uploaded patch file.
-
+  <p/>
+  Or, if you have a new main or patch expansion file, and want to apply that
+  same file to multiple APKs being uploaded, name the expansion file according
+  to the <i>lowest</i> versionCode that you're uploading. That expansion file
+  will then be uploaded, and applied to the APKs with higher versionCodes that
+  were uploaded in the same build.
   <hr/>
   This field supports substituting environment variables in the form
   <tt>${SOME_VARIABLE}</tt> or <tt>$SOME_VARIABLE</tt> at build time.


### PR DESCRIPTION
i.e. if you have a new main or patch expansion file, and want to apply that same file to multiple APKs being uploaded, previously you would have to create multiple copies of the same expansion file and upload them all.

Now you can name the expansion file to be uploaded according to the lowest versionCode that you're uploading. That expansion file will then be uploaded, and applied to the APKs with higher versionCodes that were uploaded in the same build.

This implements the intention behind #13.

Console output from testing this, where subsequent APKs re-use the expansion file uploaded during the build:
```
Handling expansion files for versionCode 1720
- Uploading new main expansion file: main.1720.net.example.testapp.obb
- Applying patch expansion file from previous APK: 1691

Handling expansion files for versionCode 1721
- Applying main expansion file from previous APK: 1720
- Applying patch expansion file from previous APK: 1691

Handling expansion files for versionCode 1722
- Applying main expansion file from previous APK: 1720
- Applying patch expansion file from previous APK: 1691

Handling expansion files for versionCode 1723
- Applying main expansion file from previous APK: 1720
- Applying patch expansion file from previous APK: 1691

Setting rollout to target 56.789% of beta track users
The beta release track will now contain the version code(s): 1720, 1721, 1722, 1723
```