### PR TITLE
Add a config option to acknowledge the bundle installation warning

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
@@ -56,6 +56,7 @@ public class ApkPublisher extends GooglePlayPublisher {
     private String deobfuscationFilesPattern;
     private String expansionFilesPattern;
     private boolean usePreviousExpansionFilesIfMissing;
+    private boolean ackBundleInstallationWarning;
     @VisibleForTesting String trackName;
     private Double rolloutPercent;
     private RecentChanges[] recentChangeList;
@@ -178,6 +179,19 @@ public class ApkPublisher extends GooglePlayPublisher {
 
     public boolean getUsePreviousExpansionFilesIfMissing() {
         return usePreviousExpansionFilesIfMissing;
+    }
+
+    public boolean getAckBundleInstallationWarning() {
+        return ackBundleInstallationWarning;
+    }
+
+    @DataBoundSetter
+    public void setAckBundleInstallationWarning(Boolean value) {
+        if (value == null) {
+            this.ackBundleInstallationWarning = false;
+        } else {
+            this.ackBundleInstallationWarning = value;
+        }
     }
 
     @DataBoundSetter
@@ -462,8 +476,9 @@ public class ApkPublisher extends GooglePlayPublisher {
         try {
             GoogleRobotCredentials credentials = getCredentialsHandler().getServiceAccountCredentials();
             return workspace.act(new ApkUploadTask(listener, credentials, applicationId, workspace, validFiles,
-                    expansionFiles, usePreviousExpansionFilesIfMissing, fromConfigValue(getCanonicalTrackName()),
-                    getRolloutPercent(), getExpandedRecentChangesList()));
+                    expansionFiles, usePreviousExpansionFilesIfMissing, ackBundleInstallationWarning,
+                    fromConfigValue(getCanonicalTrackName()), getRolloutPercent(),
+                    getExpandedRecentChangesList()));
         } catch (UploadException e) {
             logger.println(String.format("Upload failed: %s", getPublisherErrorMessage(e)));
             logger.println("No changes have been applied to the Google Play account");

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
@@ -40,6 +40,7 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
     private final List<UploadFile> appFilesToUpload;
     private final Map<Long, ExpansionFileSet> expansionFiles;
     private final boolean usePreviousExpansionFilesIfMissing;
+    private final boolean ackBundleInstallationWarning;
     private final RecentChanges[] recentChangeList;
     private final List<Long> existingVersionCodes;
     private long latestMainExpansionFileVersionCode;
@@ -48,13 +49,15 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
     // TODO: Could be renamed
     ApkUploadTask(TaskListener listener, GoogleRobotCredentials credentials, String applicationId,
                   FilePath workspace, List<UploadFile> appFilesToUpload, Map<Long, ExpansionFileSet> expansionFiles,
-                  boolean usePreviousExpansionFilesIfMissing, ReleaseTrack track, double rolloutPercentage,
+                  boolean usePreviousExpansionFilesIfMissing, boolean ackBundleInstallationWarning,
+                  ReleaseTrack track, double rolloutPercentage,
                   ApkPublisher.RecentChanges[] recentChangeList) {
         super(listener, credentials, applicationId, track, rolloutPercentage);
         this.workspace = workspace;
         this.appFilesToUpload = appFilesToUpload;
         this.expansionFiles = expansionFiles;
         this.usePreviousExpansionFilesIfMissing = usePreviousExpansionFilesIfMissing;
+        this.ackBundleInstallationWarning = ackBundleInstallationWarning;
         this.recentChangeList = recentChangeList;
         this.existingVersionCodes = new ArrayList<>();
     }
@@ -109,7 +112,8 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
             FileContent fileContent = new FileContent("application/octet-stream", fileToUpload);
             final long uploadedVersionCode;
             if (fileFormat == AppFileFormat.BUNDLE) {
-                Bundle uploadedBundle = editService.bundles().upload(applicationId, editId, fileContent).execute();
+                Bundle uploadedBundle = editService.bundles().upload(applicationId, editId, fileContent)
+                        .setAckBundleInstallationWarning(ackBundleInstallationWarning).execute();
                 uploadedVersionCode = uploadedBundle.getVersionCode();
                 uploadedVersionCodes.add(uploadedVersionCode);
             } else {

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
@@ -21,6 +21,10 @@
         field="usePreviousExpansionFilesIfMissing" />
   </f:entry>
 
+  <f:entry title="${%Ack bundle installation warning}" field="ackBundleInstallationWarning">
+    <f:checkbox default="false" />
+  </f:entry>
+
   <f:entry title="${%Release track}" field="trackName">
     <f:combobox style="width:15em" default="${descriptor.defaultTrackName}" />
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-ackBundleInstallationWarning.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-ackBundleInstallationWarning.html
@@ -1,0 +1,4 @@
+<div>
+  Should be checked if the bundle installation may trigger a warning on user devices
+  (for example, if installation size may be over a threshold, typically 100 MB).
+</div>

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
@@ -373,7 +373,7 @@ public class ApkPublisherTest {
                         new FakeListApksResponse().setEmptyApks())
                 .withResponse("/edits/the-edit-id/bundles",
                         new FakeListBundlesResponse().setEmptyBundles())
-                .withResponse("/edits/the-edit-id/bundles?uploadType=resumable",
+                .withResponse("/edits/the-edit-id/bundles?ackBundleInstallationWarning=false&uploadType=resumable",
                         new FakeUploadBundleResponse().willContinue())
                 .withResponse("google.local/uploading/foo/bundle",
                         new FakePutBundleResponse().success(43, "the:sha"))


### PR DESCRIPTION
According to [documentation](https://developers.google.com/android-publisher/api-ref/edits/bundles/upload), the bundle upload request parameter `ackBundleInstallationWarning` must be set to `true` if the bundle installation may trigger a warning on user devices. This PR adds a config option allowing to set up this request parameter on a per job basis.