### PR TITLE
[JENKINS-56508] Deal with Google Play credentials in folders

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,14 @@
       <scope>test</scope>
     </dependency>
 
+    <!-- Install Folders, so we can test credentials and jobs inside folders -->
+    <dependency>
+      <groupId>org.jenkins-ci.plugins</groupId>
+      <artifactId>cloudbees-folder</artifactId>
+      <version>6.12</version>
+      <scope>test</scope>
+    </dependency>
+
     <!-- Install Pipeline when running locally, so we can test Pipelines -->
     <!-- Versions don't need to be supplied, as they come from the BOM below -->
     <dependency>

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
@@ -460,7 +460,7 @@ public class ApkPublisher extends GooglePlayPublisher {
 
         // Upload the file(s) from the workspace
         try {
-            GoogleRobotCredentials credentials = getCredentialsHandler().getServiceAccountCredentials();
+            GoogleRobotCredentials credentials = getCredentialsHandler().getServiceAccountCredentials(run.getParent());
             return workspace.act(new ApkUploadTask(listener, credentials, applicationId, workspace, validFiles,
                     expansionFiles, usePreviousExpansionFilesIfMissing, fromConfigValue(getCanonicalTrackName()),
                     getRolloutPercent(), getExpandedRecentChangesList()));

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
@@ -268,7 +268,7 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
 
         // Assign the APKs to the desired track
         try {
-            GoogleRobotCredentials credentials = getCredentialsHandler().getServiceAccountCredentials();
+            GoogleRobotCredentials credentials = getCredentialsHandler().getServiceAccountCredentials(run.getParent());
             return workspace.act(new TrackAssignmentTask(listener, credentials, applicationId, versionCodeList,
                             fromConfigValue(getCanonicalTrackName()), getRolloutPercent()));
         } catch (UploadException e) {

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/TestsHelper.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/TestsHelper.java
@@ -1,6 +1,11 @@
 package org.jenkinsci.plugins.googleplayandroidpublisher.internal;
 
+import com.cloudbees.hudson.plugins.folder.Folder;
+import com.cloudbees.hudson.plugins.folder.properties.FolderCredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsProvider;
+import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
+import com.cloudbees.plugins.credentials.domains.Domain;
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential;
 import com.google.api.services.androidpublisher.AndroidPublisher;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
@@ -11,12 +16,38 @@ import hudson.model.queue.QueueTaskFuture;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.oauth.TestCredentials;
 import org.jvnet.hudson.test.JenkinsRule;
 
+import javax.annotation.Nonnull;
+import java.io.IOException;
+
 public class TestsHelper {
-    public static void setUpCredentials(String name) throws Exception {
+    public static void setUpCredentials(String name) {
         GoogleRobotCredentials fakeCredentials = new TestCredentials(name);
         SystemCredentialsProvider.getInstance()
                 .getCredentials()
                 .add(fakeCredentials);
+    }
+
+    public static void setUpCredentials(String name, Folder folder) throws IOException {
+        Iterable<CredentialsStore> stores = CredentialsProvider.lookupStores(folder);
+        for (CredentialsStore store : stores) {
+            if (store.getProvider() instanceof FolderCredentialsProvider && store.getContext() == folder) {
+                GoogleRobotCredentials fakeCredentials = new TestCredentials(name);
+                store.addCredentials(Domain.global(), fakeCredentials);
+                return;
+            }
+        }
+        throw new IllegalStateException("Credentials store does not exist for folder: " + folder.getFullName());
+    }
+
+    @Nonnull
+    private static CredentialsStore getFolderCredentialsStore(Folder folder) {
+        Iterable<CredentialsStore> stores = CredentialsProvider.lookupStores(folder);
+        for (CredentialsStore store : stores) {
+            if (store.getProvider() instanceof FolderCredentialsProvider && store.getContext() == folder) {
+                return store;
+            }
+        }
+        throw new IllegalStateException("Credentials store does not exist for folder: " + folder.getFullName());
     }
 
     /**


### PR DESCRIPTION
**Ticket:** [JENKINS-56508][0]

**Description:**
During job configuration, and at runtime, any Google Play credentials defined in a folder are now visible to jobs in that folder (or in nested folders).

Previously, we were always delegating to the credential lookup methods [provided][1] [by][2] the Google OAuth plugin, which always searches for credentials at the root level, meaning that it doesn't know about credentials defined in folders.

We now have our own credential lookup methods — pretty much identical to the ones in the Google OAuth plugin — but include the current context when doing the lookup.

**Testing:**
Added a test case for Freestyle jobs, and tested manually, also with existing Freestyle and Pipeline jobs.

[0]:https://issues.jenkins-ci.org/browse/JENKINS-56508
[1]:https://github.com/jenkinsci/google-oauth-plugin/blob/google-oauth-plugin-1.0.0/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java#L141-L143
[2]:https://github.com/jenkinsci/google-oauth-plugin/blob/google-oauth-plugin-1.0.0/src/main/java/com/google/jenkins/plugins/credentials/oauth/GoogleRobotCredentials.java#L154-L156