### PR TITLE
[JENKINS-40506] Allow creating releases as a draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Enables Jenkins to manage and upload Android app files (AAB or APK) to Google Pl
    - With the option to re-use expansion files from existing APKs, e.g. for patch releases
 - Assigning apps to internal, alpha, beta or production release tracks
   - This includes a build step for moving existing versions to a different track, or updating the rollout percentage   
-    e.g. You can upload an alpha in one job, then later have another
-        job promote it to beta
+    e.g. You can upload an alpha in one job, then later have another job promote it to beta
 - Staged rollout of apps to any release track
+- Uploading files without yet rolling out, creating a draft release
 - Assigning release notes to uploaded files, for various languages
 - Changing the Jenkins build result to failed if the configuration is bad, or uploading or moving app files fails for some reason
 -  Every configuration field supports variable and [token][plugin-token-macro] expansion, allowing release notes to be dynamically generated, for example
@@ -36,7 +36,6 @@ Note that having admin access is not enough; you need the account owner.
 You can see who the account owner is under [Settings → User accounts & rights][gp-console-admin] in the Google Play developer console.
 
 ### Please note
-- Any APKs uploaded will be published by Google Play immediately; they will not be held in a draft or pending state
 - The app being uploaded must already exist in Google Play; you cannot use the API to upload brand new apps
 
 ## Setup
@@ -135,6 +134,7 @@ The following job setup process is demonstrated in this video:
    - If nothing is entered, the default is `'production'`
 7. Optionally specify a [rollout percentage][gp-docs-rollout]
    - If nothing is entered, the default is to roll out to 100% of users
+   - If 0% is entered, the given file(s) will be uploaded as a draft release, leaving any existing rollout unaffected
 8. Optionally choose "Add language" to associate release notes with the uploaded APK(s)
    - You add entries for as many or as few of your supported language as you wish, but each language must already have been added to your app, under the "Store Listing" section in the Google Play Developer Console.
 
@@ -153,6 +153,7 @@ See the inline help for more details.
 If you have already uploaded an app to the alpha track (for example), you can later use Jenkins to re-assign that version to the beta or production release track.
 
 Under the "Build" section of the job configuration, add the "Move Android apps to a different release track" build step and configure the new release track.
+By setting the rollout percentage to 0%, you have the option of creating a draft release — i.e. the app files are assigned to a new release track, but not yet made available to users.
 
 You can tell Jenkins **which** version codes should be moved by either entering the values directly, or by providing AAB or APK files, from which the plugin will read the application ID and version codes for you.
 

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackPublisherTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackPublisherTask.java
@@ -35,12 +35,23 @@ abstract class TrackPublisherTask<V> extends AbstractPublisherTask<V> {
                 .setTrack(track.getApiValue())
                 .setReleases(Collections.singletonList(release));
 
+        final boolean isDraft = release.getStatus().equals("draft");
+        if (!isDraft) {
+            logger.println(String.format("Setting rollout to target %s%% of %s track users",
+                    PERCENTAGE_FORMATTER.format(rolloutFraction * 100), track));
+        }
+
         // Assign the new file(s) to the desired track
-        logger.println(String.format("Setting rollout to target %s%% of %s track users",
-                        PERCENTAGE_FORMATTER.format(rolloutFraction * 100), track));
         Track updatedTrack =
                 editService.tracks().update(applicationId, editId, trackToAssign.getTrack(), trackToAssign).execute();
-        logger.println(String.format("The %s release track will now contain the version code(s): %s%n", track,
+
+        final String msgFormat;
+        if (isDraft) {
+            msgFormat = "New %s draft release created, with the version code(s): %s%n";
+        } else {
+            msgFormat = "The %s release track will now contain the version code(s): %s%n";
+        }
+        logger.println(String.format(msgFormat, track,
                 join(updatedTrack.getReleases().get(0).getVersionCodes(), ", ")));
     }
 

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/Util.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/Util.java
@@ -121,13 +121,25 @@ public class Util {
         return null;
     }
 
-    static TrackRelease buildRelease(List<Long> versionCodes, double userFraction, @Nullable List<LocalizedText> releaseNotes) {
-        // We need to explicitly set the fraction to null if it's not 0 < x < 1.
-        // If so, then we also mark the rollout as done, rather than in-progress:
-        // https://developers.google.com/android-publisher/api-ref/edits/tracks#resource
-        boolean hasValidFraction = (Double.compare(userFraction, 0) != 0) && (Double.compare(userFraction, 1) != 0);
-        Double fraction = hasValidFraction ? userFraction : null;
-        String status = hasValidFraction ? "inProgress" : "completed";
+    static TrackRelease buildRelease(
+        List<Long> versionCodes, double userFraction, @Nullable List<LocalizedText> releaseNotes
+    ) {
+        final String status;
+        final Double fraction;
+
+        boolean isDraftRelease = Double.compare(userFraction, 0) == 0;
+        boolean isFullRollout = Double.compare(userFraction, 1) == 0;
+
+        if (isDraftRelease) {
+            status = "draft";
+            fraction = null;
+        } else if (isFullRollout) {
+            status = "completed";
+            fraction = null;
+        } else {
+            status = "inProgress";
+            fraction = userFraction;
+        }
 
         TrackRelease release = new TrackRelease()
                 .setVersionCodes(versionCodes)

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-rolloutPercentage.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-rolloutPercentage.html
@@ -4,9 +4,12 @@
   <p/>
   If you enter no value here, or 100%, the app will be rolled out to all users.
   <p/>
+  If you enter 0%, a draft release will be created, meaning that users will not yet see it;
+  the existing file(s) released in the given track, if any, will remain in place.
+  <p/>
   For more information on staged rollouts, see the Google Play documentation:<br/>
-  <a href='https://support.google.com/googleplay/android-developer/answer/3131213'>
-    https://support.google.com/googleplay/android-developer/answer/3131213
+  <a href='https://support.google.com/googleplay/android-developer/answer/6346149'>
+    https://support.google.com/googleplay/android-developer/answer/6346149
   </a>
   <hr/>
   This field supports substituting environment variables in the form

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/help-rolloutPercentage.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/help-rolloutPercentage.html
@@ -4,9 +4,12 @@
   <p/>
   If you enter no value here, or 100%, the app will be rolled out to all users.
   <p/>
+  If you enter 0%, a draft release will be created, meaning that users will not yet see it;
+  the existing file(s) released in the given track, if any, will remain in place.
+  <p/>
   For more information on staged rollouts, see the Google Play documentation:<br/>
-  <a href='https://support.google.com/googleplay/android-developer/answer/3131213'>
-    https://support.google.com/googleplay/android-developer/answer/3131213
+  <a href='https://support.google.com/googleplay/android-developer/answer/6346149'>
+    https://support.google.com/googleplay/android-developer/answer/6346149
   </a>
   <hr/>
   This field supports substituting environment variables in the form

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/UtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/UtilsTest.java
@@ -5,13 +5,15 @@ import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import com.google.api.services.androidpublisher.model.LocalizedText;
 import com.google.api.services.androidpublisher.model.TrackRelease;
+import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestUtilImpl;
+import org.junit.Before;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.security.GeneralSecurityException;
 import java.util.Arrays;
 import java.util.List;
-import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestUtilImpl;
-import org.junit.Before;
-import org.junit.Test;
+
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
@@ -40,13 +42,23 @@ public class UtilsTest {
     }
 
     @Test
-    public void buildRelease_withInvalidFraction_releaseIsComplete() {
+    public void buildRelease_withZeroFraction_releaseIsComplete() {
         List<Long> versionCodes = Arrays.asList(1L, 2L, 3L);
         double fraction = 0.0;
         TrackRelease track = Util.buildRelease(versionCodes, fraction, null);
 
         assertNull(track.getUserFraction());
-        assertEquals("completed", track.getStatus());
+        assertEquals("draft", track.getStatus());
+    }
+
+    @Test
+    public void buildRelease_withNonZeroFraction_releaseIsInProgress() {
+        List<Long> versionCodes = Arrays.asList(1L, 2L, 3L);
+        double fraction = 0.123;
+        TrackRelease track = Util.buildRelease(versionCodes, fraction, null);
+
+        assertEquals(0.123, track.getUserFraction(), 0.0001);
+        assertEquals("inProgress", track.getStatus());
     }
 
     @Test

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/TestsHelper.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/TestsHelper.java
@@ -7,12 +7,14 @@ import com.cloudbees.plugins.credentials.CredentialsStore;
 import com.cloudbees.plugins.credentials.SystemCredentialsProvider;
 import com.cloudbees.plugins.credentials.domains.Domain;
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential;
+import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.androidpublisher.AndroidPublisher;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.queue.QueueTaskFuture;
 import jenkins.model.ParameterizedJobMixIn;
+import junit.framework.AssertionFailedError;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.oauth.TestCredentials;
 import org.jvnet.hudson.test.JenkinsRule;
 
@@ -52,6 +54,23 @@ public class TestsHelper {
                 .setApplicationName("Jenkins-GooglePlayAndroidPublisher-tests")
                 .setSuppressAllChecks(true)
                 .build();
+    }
+
+    /**
+     * Attempts to return the body of an HTTP request that was made.
+     *
+     * @param urlSuffix Suffix of the URL whose body should be returned.
+     * @param <T> Type of the body.
+     * @return The HTTP request body as an instance of type T; throws if the request was not made.
+     */
+    public static <T> T getRequestBodyForUrl(TestHttpTransport transport, String urlSuffix, Class<T> cls) throws IOException {
+        String json = transport.getRemoteCalls().stream()
+            .filter(remoteCall -> remoteCall.url.endsWith(urlSuffix))
+            .findFirst()
+            .orElseThrow(() -> new AssertionFailedError("Expected call to URL: " + urlSuffix))
+            .request
+            .getContentAsString();
+        return JacksonFactory.getDefaultInstance().createJsonParser(json).parse(cls);
     }
 
     /**


### PR DESCRIPTION
**Ticket:**
https://issues.jenkins-ci.org/browse/JENKINS-40506

**Description:**
Added the ability to create a draft release by specifying a rollout percentage of zero.
This works for both uploading APK or AAB files, or when moving files between release tracks.

**Testing:**
Added automated tests for both types of build step, and also did some manual testing.