### PR TITLE
[JENKINS-62389] Acknowledge installation warning when uploading large bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ You can see who the account owner is under [Settings → User accounts & rights]
 - Any APKs uploaded will be published by Google Play immediately; they will not be held in a draft or pending state
 - The app being uploaded must already exist in Google Play; you cannot use the API to upload brand new apps
 
+#### Bundle size warnings
+If you try to upload an AAB file to Google Play (including manually via the Google Play Developer Console), and its size is perhaps 100MB+, it may give you a warning:
+> The installation of the app bundle may be too large and trigger user warning on some devices […] this needs to be explicitly acknowledged
+
+Unfortunately, this "user warning" that may be shown, presumably when a user installs your app from Google Play, does not appear to be documented.  
+This plugin automatically "acknowledges" that warning on Google Play on your behalf when uploading any AAB files, regardless of their size, so you should not see any errors.
+
+If you _do_ see see any unexpected behaviour related to uploading bundles, or warnings appearing for end users, please [let us know](#feedback).
+
 ## Setup
 ### One-time: Set up Google Play credentials
 The following initial setup process is demonstrated in this video: [https://www.youtube.com/watch?v=txdPSJF94RM][demo-video-creds] (note that Google has changed the Google API Console (at least twice) since this video was recorded; steps 3–13 in the "Create Google service account" section below have the updated info)

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
@@ -11,6 +11,9 @@ import com.google.api.services.androidpublisher.model.TrackRelease;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import hudson.FilePath;
 import hudson.model.TaskListener;
+import org.jenkinsci.plugins.googleplayandroidpublisher.internal.AppFileFormat;
+import org.jenkinsci.plugins.googleplayandroidpublisher.internal.UploadFile;
+
 import java.io.File;
 import java.io.IOException;
 import java.net.SocketTimeoutException;
@@ -25,9 +28,7 @@ import java.util.Set;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import org.jenkinsci.plugins.googleplayandroidpublisher.internal.AppFileFormat;
-import org.jenkinsci.plugins.googleplayandroidpublisher.internal.UploadFile;
-
+import static hudson.Functions.humanReadableByteSize;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.ApkPublisher.ExpansionFileSet;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.ApkPublisher.RecentChanges;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.DEOBFUSCATION_FILE_TYPE_PROGUARD;
@@ -91,6 +92,7 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
             // Log some useful information about the file that will be uploaded
             final String fileType = (fileFormat == AppFileFormat.BUNDLE) ? "AAB" : "APK";
             logger.println(String.format("      %s file: %s", fileType, getRelativeFileName(appFile.getFilePath())));
+            logger.println(String.format("     File size: %s", humanReadableByteSize(appFile.getFilePath().length())));
             logger.println(String.format("    SHA-1 hash: %s", appFile.getSha1Hash()));
             logger.println(String.format("   versionCode: %d", appFile.getVersionCode()));
             logger.println(String.format(" minSdkVersion: %s", appFile.getMinSdkVersion()));

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
@@ -111,7 +111,10 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
             FileContent fileContent = new FileContent("application/octet-stream", fileToUpload);
             final long uploadedVersionCode;
             if (fileFormat == AppFileFormat.BUNDLE) {
-                Bundle uploadedBundle = editService.bundles().upload(applicationId, editId, fileContent).execute();
+                Bundle uploadedBundle = editService.bundles().upload(applicationId, editId, fileContent)
+                        // Prevent Google Play error when uploading large bundles
+                        .setAckBundleInstallationWarning(true)
+                        .execute();
                 uploadedVersionCode = uploadedBundle.getVersionCode();
                 uploadedVersionCodes.add(uploadedVersionCode);
             } else {

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
@@ -575,7 +575,7 @@ public class ApkPublisherTest {
                         new FakeListApksResponse().setEmptyApks())
                 .withResponse("/edits/the-edit-id/bundles",
                         new FakeListBundlesResponse().setEmptyBundles())
-                .withResponse("/edits/the-edit-id/bundles?uploadType=resumable",
+                .withResponse("/edits/the-edit-id/bundles?ackBundleInstallationWarning=true&uploadType=resumable",
                         new FakeUploadBundleResponse().willContinue())
                 .withResponse("google.local/uploading/foo/bundle",
                         new FakePutBundleResponse().success(43, "the:sha"))


### PR DESCRIPTION
**Ticket:**
https://issues.jenkins-ci.org/browse/JENKINS-62389

**Description:**
We now set the vague [`ackBundleInstallationWarning` flag](https://developers.google.com/android-publisher/api-ref/edits/bundles/upload#parameters) to `true` whenever we're uploading a bundle file, as it solves a problem with uploading certain large bundles.

**Testing:**
Updated the automated tests, and manually tested that bundle uploading still works, with tiny bundles and bundles over 100MB. I couldn't get bundles over 150MB to upload, with or without this flag, and through various tests, also via the Google Play Developer Console, I was unable to reproduce the original warning. 🤷‍♀️

Closes #25.