### PR TITLE
[JENKINS-54479] Retain release notes when assigning files to a new release track

### DIFF
--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/TestsHelper.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/TestsHelper.java
@@ -9,6 +9,9 @@ import com.cloudbees.plugins.credentials.domains.Domain;
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.services.androidpublisher.AndroidPublisher;
+import com.google.api.services.androidpublisher.model.LocalizedText;
+import com.google.api.services.androidpublisher.model.Track;
+import com.google.api.services.androidpublisher.model.TrackRelease;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -19,6 +22,10 @@ import org.jenkinsci.plugins.googleplayandroidpublisher.internal.oauth.TestCrede
 import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
 
@@ -71,6 +78,24 @@ public class TestsHelper {
             .request
             .getContentAsString();
         return JacksonFactory.getDefaultInstance().createJsonParser(json).parse(cls);
+    }
+
+    public static Track track(String name, TrackRelease... releases) {
+        return new Track().setTrack(name).setReleases(Arrays.asList(releases));
+    }
+
+    public static TrackRelease release(long versionCode, String... languages) {
+        TrackRelease release = new TrackRelease();
+        release.setVersionCodes(Collections.singletonList(versionCode));
+        List<LocalizedText> releaseNotes = null;
+        if (languages.length > 0) {
+            releaseNotes = new ArrayList<>();
+            for (String lang : languages) {
+                releaseNotes.add(new LocalizedText().setLanguage(lang).setText("Notes: " + lang));
+            }
+        }
+        release.setReleaseNotes(releaseNotes);
+        return release;
     }
 
     /**

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/responses/FakeListTracksResponse.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/responses/FakeListTracksResponse.java
@@ -1,0 +1,21 @@
+package org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses;
+
+import com.google.api.services.androidpublisher.model.Track;
+import com.google.api.services.androidpublisher.model.TracksListResponse;
+
+import java.util.List;
+
+/**
+ * <pre>GET https://www.googleapis.com/androidpublisher/v3/applications/{appId}/edits/{editId}/tracks</pre>
+ *
+ * @see TracksListResponse Response type
+ * @see Track Response inner type
+ * @see com.google.api.services.androidpublisher.AndroidPublisher.Edits.Tracks#list Request method
+ */
+public class FakeListTracksResponse extends FakeHttpResponse<FakeListTracksResponse> {
+    public FakeListTracksResponse setTracks(List<Track> tracks) {
+        return setSuccessData(new TracksListResponse()
+                .setKind("androidpublisher#tracksListResponse")
+                .setTracks(tracks));
+    }
+}


### PR DESCRIPTION
**Ticket:**
https://issues.jenkins-ci.org/browse/JENKINS-54479

**Description:**
Copying over the release notes isn't done automatically by Google Play when promoting existing files to another release track (unlike in the web UI).

So we now search for an existing track that contains one of the versionCodes we want to move, and apply its associated release notes, if any, to the new track.

**Testing:**
Extended the automated tests to include an existing track with release notes, and we verify that those release notes are then applied to the new release track. Also tested a couple of scenarios manually.