### PR TITLE
[JENKINS-62398] Make release track name mandatory in job configuration

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
@@ -26,6 +26,7 @@ import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.export.Exported;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Serializable;
@@ -105,7 +106,7 @@ public class ApkPublisher extends GooglePlayPublisher {
     }
 
     @DataBoundSetter
-    public void setFilesPattern(@Nonnull String pattern) {
+    public void setFilesPattern(String pattern) {
         this.filesPattern = DescriptorImpl.defaultFilesPattern.equals(pattern) ? null : pattern;
     }
 
@@ -164,13 +165,13 @@ public class ApkPublisher extends GooglePlayPublisher {
     }
 
     @DataBoundSetter
-    public void setTrackName(@Nonnull String trackName) {
-        this.trackName = DescriptorImpl.defaultTrackName.equalsIgnoreCase(trackName) ? null : trackName;
+    public void setTrackName(String trackName) {
+        this.trackName = trackName;
     }
 
-    @Nonnull
+    @Nullable
     public String getTrackName() {
-        return fixEmptyAndTrim(trackName) == null ? DescriptorImpl.defaultTrackName : trackName;
+        return fixEmptyAndTrim(trackName);
     }
 
     @DataBoundSetter
@@ -609,7 +610,6 @@ public class ApkPublisher extends GooglePlayPublisher {
     @Extension
     public static final class DescriptorImpl extends GooglePlayBuildStepDescriptor<Publisher> {
         public static final String defaultFilesPattern = "**/build/outputs/**/*.aab, **/build/outputs/**/*.apk";
-        public static final String defaultTrackName = ReleaseTrack.PRODUCTION.getApiValue();
         public static final int defaultRolloutPercent = 100;
 
         public String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
@@ -277,7 +277,7 @@ public class ApkPublisher extends GooglePlayPublisher {
         final String trackName = getCanonicalTrackName();
         final ReleaseTrack track = fromConfigValue(trackName);
         if (trackName == null) {
-            errors.add("Release track was not specified");
+            errors.add("Release track was not specified; this is now a mandatory parameter");
         } else if (track == null) {
             errors.add(String.format("'%s' is not a valid release track", trackName));
         } else {

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
@@ -134,15 +134,19 @@ public class ApkPublisher extends GooglePlayPublisher {
             this.rolloutPercentage = percentage;
             return;
         }
-        this.rolloutPercentage = pct.intValue() == DescriptorImpl.defaultRolloutPercent ? null : pctStr;
+        this.rolloutPercentage = pct.intValue() == DescriptorImpl.defaultRolloutPercentage ? null : pctStr;
     }
 
     @Nonnull
     public String getRolloutPercentage() {
-        if (fixEmptyAndTrim(rolloutPercentage) == null) {
-            return String.valueOf(DescriptorImpl.defaultRolloutPercent);
+        String pct = fixEmptyAndTrim(rolloutPercentage);
+        if (pct == null) {
+            pct = String.valueOf(DescriptorImpl.defaultRolloutPercentage);
         }
-        return rolloutPercentage;
+        if (!pct.endsWith("%") && !pct.matches(REGEX_VARIABLE)) {
+            pct += "%";
+        }
+        return pct;
     }
 
     // Required for Pipeline builds using the deprecated `rolloutPercent` option
@@ -610,7 +614,7 @@ public class ApkPublisher extends GooglePlayPublisher {
     @Extension
     public static final class DescriptorImpl extends GooglePlayBuildStepDescriptor<Publisher> {
         public static final String defaultFilesPattern = "**/build/outputs/**/*.aab, **/build/outputs/**/*.apk";
-        public static final int defaultRolloutPercent = 100;
+        public static final int defaultRolloutPercentage = 100;
 
         public String getDisplayName() {
             return "Upload Android AAB/APKs to Google Play";

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
@@ -144,15 +144,19 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
             this.rolloutPercentage = percentage;
             return;
         }
-        this.rolloutPercentage = pct.intValue() == DescriptorImpl.defaultRolloutPercent ? null : pctStr;
+        this.rolloutPercentage = pct.intValue() == DescriptorImpl.defaultRolloutPercentage ? null : pctStr;
     }
 
     @Nonnull
     public String getRolloutPercentage() {
-        if (fixEmptyAndTrim(rolloutPercentage) == null) {
-            return String.valueOf(DescriptorImpl.defaultRolloutPercent);
+        String pct = fixEmptyAndTrim(rolloutPercentage);
+        if (pct == null) {
+            pct = String.valueOf(ApkPublisher.DescriptorImpl.defaultRolloutPercentage);
         }
-        return rolloutPercentage;
+        if (!pct.endsWith("%") && !pct.matches(REGEX_VARIABLE)) {
+            pct += "%";
+        }
+        return pct;
     }
 
     // Required for Pipeline builds using the deprecated `rolloutPercent` option
@@ -369,7 +373,7 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
     @Extension
     public static final class DescriptorImpl extends GooglePlayBuildStepDescriptor<Builder> {
         public static final String defaultFilesPattern = "**/build/outputs/**/*.aab, **/build/outputs/**/*.apk";
-        public static final int defaultRolloutPercent = 100;
+        public static final int defaultRolloutPercentage = 100;
 
         public String getDisplayName() {
             return "Move Android apps to a different release track";

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
@@ -16,6 +16,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.ArrayList;
@@ -143,13 +144,13 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
             this.rolloutPercentage = percentage;
             return;
         }
-        this.rolloutPercentage = pct.intValue() == ApkPublisher.DescriptorImpl.defaultRolloutPercent ? null : pctStr;
+        this.rolloutPercentage = pct.intValue() == DescriptorImpl.defaultRolloutPercent ? null : pctStr;
     }
 
     @Nonnull
     public String getRolloutPercentage() {
         if (fixEmptyAndTrim(rolloutPercentage) == null) {
-            return String.valueOf(ApkPublisher.DescriptorImpl.defaultRolloutPercent);
+            return String.valueOf(DescriptorImpl.defaultRolloutPercent);
         }
         return rolloutPercentage;
     }
@@ -174,13 +175,13 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
     }
 
     @DataBoundSetter
-    public void setTrackName(@Nonnull String trackName) {
-        this.trackName = DescriptorImpl.defaultTrackName.equalsIgnoreCase(trackName) ? null : trackName;
+    public void setTrackName(String trackName) {
+        this.trackName = trackName;
     }
 
-    @Nonnull
+    @Nullable
     public String getTrackName() {
-        return fixEmptyAndTrim(trackName) == null ? DescriptorImpl.defaultTrackName : trackName;
+        return fixEmptyAndTrim(trackName);
     }
 
     private String getExpandedApplicationId() throws IOException, InterruptedException {
@@ -368,7 +369,6 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
     @Extension
     public static final class DescriptorImpl extends GooglePlayBuildStepDescriptor<Builder> {
         public static final String defaultFilesPattern = "**/build/outputs/**/*.aab, **/build/outputs/**/*.apk";
-        public static final String defaultTrackName = ReleaseTrack.PRODUCTION.getApiValue();
         public static final int defaultRolloutPercent = 100;
 
         public String getDisplayName() {

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
@@ -240,7 +240,7 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
         final String trackName = getCanonicalTrackName();
         final ReleaseTrack track = fromConfigValue(trackName);
         if (trackName == null) {
-            errors.add("Release track was not specified");
+            errors.add("Release track was not specified; this is now a mandatory parameter");
         } else if (track == null) {
             errors.add(String.format("'%s' is not a valid release track", trackName));
         } else {

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
@@ -27,7 +27,7 @@
 
   <f:entry title="${%Rollout %}" field="rolloutPercentage"
       description="${%Defaults to 100% if not set}">
-    <f:combobox style="width:15em" default="${descriptor.defaultRolloutPercent}" />
+    <f:textbox style="width:15em" default="${descriptor.defaultRolloutPercentage}%" />
   </f:entry>
 
   <f:entry title="${%Recent changes}" field="recentChangeList">

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
@@ -22,7 +22,7 @@
   </f:entry>
 
   <f:entry title="${%Release track}" field="trackName">
-    <f:combobox style="width:15em" default="${descriptor.defaultTrackName}" />
+    <f:combobox style="width:15em" />
   </f:entry>
 
   <f:entry title="${%Rollout %}" field="rolloutPercentage"

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/config.jelly
@@ -35,7 +35,7 @@
 
   <f:entry title="${%Rollout %}" field="rolloutPercentage"
       description="${%Defaults to 100% if not set}">
-    <f:combobox style="width:15em" default="${descriptor.defaultRolloutPercent}" />
+    <f:textbox style="width:15em" default="${descriptor.defaultRolloutPercentage}%" />
   </f:entry>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/config.jelly
@@ -30,7 +30,7 @@
   </f:radioBlock>
 
   <f:entry title="${%Release track}" field="trackName">
-    <f:combobox style="width:15em" default="${descriptor.defaultTrackName}" />
+    <f:combobox style="width:15em" />
   </f:entry>
 
   <f:entry title="${%Rollout %}" field="rolloutPercentage"

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
@@ -16,7 +16,6 @@ import hudson.slaves.DumbSlave;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.JenkinsUtil;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestHttpTransport;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestUtilImpl;
-import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestsHelper;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeAssignTrackResponse;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeCommitResponse;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeListApksResponse;
@@ -83,7 +82,7 @@ public class ApkPublisherTest {
 
         // Create fake AndroidPublisher client
         transport = new TestHttpTransport();
-        AndroidPublisher androidClient = TestsHelper.createAndroidPublisher(transport);
+        AndroidPublisher androidClient = createAndroidPublisher(transport);
         when(jenkinsUtil.createPublisherClient(any(), anyString())).thenReturn(androidClient);
     }
 
@@ -97,9 +96,9 @@ public class ApkPublisherTest {
     @Test
     public void configRoundtripWorks() throws Exception {
         // Given that a few credentials have been set up
-        TestsHelper.setUpCredentials("credential-a");
-        TestsHelper.setUpCredentials("credential-b");
-        TestsHelper.setUpCredentials("credential-c");
+        setUpCredentials("credential-a");
+        setUpCredentials("credential-b");
+        setUpCredentials("credential-c");
 
         // And we have a job configured with the APK publisher, which includes all possible configuration options
         FreeStyleProject project = j.createFreeStyleProject();
@@ -200,11 +199,11 @@ public class ApkPublisherTest {
         publisher.setTrackName("production");
         p.getPublishersList().add(publisher);
 
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         setUpApkFile(p);
 
         // When a build occurs, it should fail as the APK file already exists
-        TestsHelper.assertResultWithLogLines(j, p, Result.FAILURE,
+        assertResultWithLogLines(j, p, Result.FAILURE,
                 "Uploading 1 file(s) with application ID: org.jenkins.appId",
                 "APK file: " + join(Arrays.asList("build", "outputs", "apk", "app.apk"), File.separator),
                 "versionCode: 42",
@@ -219,7 +218,7 @@ public class ApkPublisherTest {
 
         FreeStyleProject p = j.createFreeStyleProject("uploadApks");
 
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         setUpApkFile(p);
 
         ApkPublisher publisher = new ApkPublisher();
@@ -246,7 +245,7 @@ public class ApkPublisherTest {
         // Applying changes to Google Play...
         // Changes were successfully applied to Google Play
 
-        TestsHelper.assertResultWithLogLines(j, p, Result.SUCCESS,
+        assertResultWithLogLines(j, p, Result.SUCCESS,
                 "Uploading 1 file(s) with application ID: org.jenkins.appId",
                 "APK file: " + join(Arrays.asList("build", "outputs", "apk", "app.apk"), File.separator),
                 "versionCode: 42",
@@ -293,7 +292,7 @@ public class ApkPublisherTest {
 
         // Given a folder, which has Google Play credentials attached
         Folder folder = j.createProject(Folder.class, "some-folder");
-        TestsHelper.setUpCredentials("folder-credentials", folder);
+        setUpCredentials("folder-credentials", folder);
 
         // And given there's a job in the folder which wants to use those credentials
         FreeStyleProject p = folder.createProject(FreeStyleProject.class, "some-job-in-a-folder");
@@ -305,7 +304,7 @@ public class ApkPublisherTest {
         setUpApkFile(p);
 
         // When a build occurs, it should succeed
-        TestsHelper.assertResultWithLogLines(j, p, Result.SUCCESS,
+        assertResultWithLogLines(j, p, Result.SUCCESS,
                 "Uploading 1 file(s) with application ID: org.jenkins.appId",
                 "APK file: " + join(Arrays.asList("build", "outputs", "apk", "app.apk"), File.separator),
                 "versionCode: 42",
@@ -340,12 +339,12 @@ public class ApkPublisherTest {
         p.getPublishersList().add(publisher);
 
         // And the prerequisites are in place
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         setUpTransportForApk();
         setUpApkFile(p);
 
         // When a build occurs, it should apply the default parameter values
-        TestsHelper.assertResultWithLogLines(j, p, Result.SUCCESS,
+        assertResultWithLogLines(j, p, Result.SUCCESS,
             "- Credential:     test-credentials",
             "Setting rollout to target 12.5% of production track users",
             "Changes were successfully applied to Google Play"
@@ -372,12 +371,12 @@ public class ApkPublisherTest {
         p.getPublishersList().add(publisher);
 
         // And the prerequisites are in place
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         setUpTransportForApk();
         setUpApkFile(p);
 
         // When a build occurs, it should upload as a draft
-        TestsHelper.assertResultWithLogLines(j, p, Result.SUCCESS,
+        assertResultWithLogLines(j, p, Result.SUCCESS,
             "New production draft release created, with the version code(s): 42",
             "Changes were successfully applied to Google Play"
         );
@@ -546,11 +545,11 @@ public class ApkPublisherTest {
         publisher.setTrackName("production");
         p.getPublishersList().add(publisher);
 
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         setUpBundleFile(p);
 
         // When a build occurs, it should fail as the bundle file already exists
-        TestsHelper.assertResultWithLogLines(j, p, Result.FAILURE,
+        assertResultWithLogLines(j, p, Result.FAILURE,
                 "Uploading 1 file(s) with application ID: org.jenkins.bundleAppId",
                 "AAB file: " + join(Arrays.asList("build", "outputs", "bundle", "release", "bundle.aab"), File.separator),
                 "versionCode: 43",
@@ -565,7 +564,7 @@ public class ApkPublisherTest {
 
         FreeStyleProject p = j.createFreeStyleProject("uploadBundles");
 
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         setUpBundleFile(p);
 
         ApkPublisher publisher = new ApkPublisher();
@@ -592,7 +591,7 @@ public class ApkPublisherTest {
         // Applying changes to Google Play...
         // Changes were successfully applied to Google Play
 
-        TestsHelper.assertResultWithLogLines(j, p, Result.SUCCESS,
+        assertResultWithLogLines(j, p, Result.SUCCESS,
                 "Uploading 1 file(s) with application ID: org.jenkins.bundleAppId",
                 "AAB file: " + join(Arrays.asList("build", "outputs", "bundle", "release", "bundle.aab"), File.separator),
                 "versionCode: 43",
@@ -613,7 +612,7 @@ public class ApkPublisherTest {
         publisher.setTrackName("production");
         p.getPublishersList().add(publisher);
 
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         setUpTransportForBundle();
 
         // And there are both AAB and APK files in the workspace
@@ -627,7 +626,7 @@ public class ApkPublisherTest {
 
         // When a build occurs, then we should see a warning about multiple files
         // And the AAB upload should succeed, without uploading the APK
-        TestsHelper.assertResultWithLogLines(j, p, Result.SUCCESS,
+        assertResultWithLogLines(j, p, Result.SUCCESS,
             "Both AAB and APK files were found; only the AAB files will be uploaded",
             "Uploading 1 file(s) with application ID: com.example.test",
             "AAB file: " + join(Arrays.asList("build", "outputs", "bundle", "release", "bundle.aab"), File.separator),
@@ -647,11 +646,11 @@ public class ApkPublisherTest {
                 "}", true
         ));
 
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         setUpTransportForBundle();
 
         // When a build occurs, it should succeed
-        TestsHelper.assertResultWithLogLines(j, p, Result.SUCCESS,
+        assertResultWithLogLines(j, p, Result.SUCCESS,
                 "Uploading 1 file(s) with application ID: org.jenkins.bundleAppId",
                 "AAB file: " + join(Arrays.asList("build", "outputs", "bundle", "release", "bundle.aab"), File.separator),
                 "versionCode: 43",
@@ -697,7 +696,7 @@ public class ApkPublisherTest {
         FreeStyleProject p = j.createFreeStyleProject("uploadApks");
         p.setAssignedNode(agent);
 
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         setUpApkFileOnSlave(p, agent);
 
         ApkPublisher publisher = new ApkPublisher();
@@ -724,7 +723,7 @@ public class ApkPublisherTest {
         // Applying changes to Google Play...
         // Changes were successfully applied to Google Play
 
-        TestsHelper.assertResultWithLogLines(j, p, Result.SUCCESS,
+        assertResultWithLogLines(j, p, Result.SUCCESS,
                 "Uploading 1 file(s) with application ID: org.jenkins.appId",
                 "APK file: " + join(Arrays.asList("build", "outputs", "apk", "app.apk"), File.separator),
                 "versionCode: 42",

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilderTest.java
@@ -13,7 +13,6 @@ import org.jenkinsci.plugins.googleplayandroidpublisher.internal.AndroidUtil;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.JenkinsUtil;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestHttpTransport;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestUtilImpl;
-import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestsHelper;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeAssignTrackResponse;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeCommitResponse;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeListApksResponse;
@@ -34,7 +33,9 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Stream;
 
+import static org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestsHelper.assertLogLines;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestsHelper.assertResultWithLogLines;
+import static org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestsHelper.createAndroidPublisher;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestsHelper.getRequestBodyForUrl;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestsHelper.release;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestsHelper.setUpCredentials;
@@ -63,7 +64,7 @@ public class ReleaseTrackAssignmentBuilderTest {
         when(mockAndroid.getApkPackageName(any())).thenReturn("org.jenkins.appId");
 
         // Create fake AndroidPublisher client
-        AndroidPublisher androidClient = TestsHelper.createAndroidPublisher(transport);
+        AndroidPublisher androidClient = createAndroidPublisher(transport);
         when(jenkinsUtil.createPublisherClient(any(), anyString())).thenReturn(androidClient);
 
         Util.setAndroidUtil(mockAndroid);
@@ -78,9 +79,9 @@ public class ReleaseTrackAssignmentBuilderTest {
     @Test
     public void configRoundtripWorks() throws Exception {
         // Given that a few credentials have been set up
-        TestsHelper.setUpCredentials("credential-a");
-        TestsHelper.setUpCredentials("credential-b");
-        TestsHelper.setUpCredentials("credential-c");
+        setUpCredentials("credential-a");
+        setUpCredentials("credential-b");
+        setUpCredentials("credential-c");
 
         // And we have a job configured with the builder, which includes all possible configuration options
         FreeStyleProject project = j.createFreeStyleProject();
@@ -182,7 +183,7 @@ public class ReleaseTrackAssignmentBuilderTest {
         QueueTaskFuture<FreeStyleBuild> scheduled = p.scheduleBuild2(0);
         j.assertBuildStatusSuccess(scheduled);
 
-        TestsHelper.assertLogLines(j, scheduled,
+        assertLogLines(j, scheduled,
                 "Assigning 1 version(s) with application ID org.jenkins.appId to production release track",
                 "Setting rollout to target 5% of production track users",
                 "The production release track will now contain the version code(s): 42",
@@ -209,11 +210,11 @@ public class ReleaseTrackAssignmentBuilderTest {
         p.getBuildersList().add(builder);
 
         // And the prerequisites are in place
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         setUpTransportForSuccess();
 
         // When a build occurs, it should create the release in the target track as a draft
-        TestsHelper.assertResultWithLogLines(j, p, Result.SUCCESS,
+        assertResultWithLogLines(j, p, Result.SUCCESS,
             "New production draft release created, with the version code(s): 42",
             "Changes were successfully applied to Google Play"
         );
@@ -367,10 +368,10 @@ public class ReleaseTrackAssignmentBuilderTest {
             "}", true
         ));
 
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         setUpTransportForSuccess();
 
-        TestsHelper.assertResultWithLogLines(j, p, expectedResult, expectedLogLines);
+        assertResultWithLogLines(j, p, expectedResult, expectedLogLines);
     }
 
     @Test
@@ -410,7 +411,7 @@ public class ReleaseTrackAssignmentBuilderTest {
         QueueTaskFuture<FreeStyleBuild> scheduled = p.scheduleBuild2(0);
         j.assertBuildStatusSuccess(scheduled);
 
-        TestsHelper.assertLogLines(j, scheduled,
+        assertLogLines(j, scheduled,
                 "Assigning 1 version(s) with application ID org.jenkins.appId to production release track",
                 "Setting rollout to target 5% of production track users",
                 "The production release track will now contain the version code(s): 42",
@@ -442,7 +443,7 @@ public class ReleaseTrackAssignmentBuilderTest {
 
     private ReleaseTrackAssignmentBuilder createBuilder() throws Exception {
         ReleaseTrackAssignmentBuilder builder = new ReleaseTrackAssignmentBuilder();
-        TestsHelper.setUpCredentials("test-credentials");
+        setUpCredentials("test-credentials");
         builder.setGoogleCredentialsId("test-credentials");
         builder.setApplicationId("org.jenkins.appId");
         builder.setVersionCodes("42");


### PR DESCRIPTION
**Ticket:**
https://issues.jenkins-ci.org/browse/JENKINS-62398

**Description:**
Removed `production` as the default track name for the upload build step.
⚠️ This is a breaking change, which will require users to explicitly provide the track name.

i.e. users will have to update their Freestyle and Pipeline job configurations, e.g.:
```diff
   // Upload to 100% of users in Production
-  androidApkUpload googlePlayCredentialsId: 'gp'
+  androidApkUpload googlePlayCredentialsId: 'gp',
+                   trackName 'production'
```

Without this change, if no track name is specified, they'll see this in the build console log:
> Release track was not specified; this is now a mandatory parameter

This change makes the plugin safer, as publishing to production by default, e.g. in the absence of configuration, or due to a mistake when defining a parameter, is probably unexpected behaviour for most users. As you can see in the motivation behind #26.

The README has been updated with information on the breaking change, and I'll make this clear in the CHANGELOG at the next release. I wonder whether to also [mark the plugin](https://wiki.jenkins.io/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions)  as "incompatible".

**Testing:**
Added automated tests, and did some manual testing of the config UI, snippet generator, and running builds.

Closes #26.