### PR TITLE
[JENKINS-62516] Make rollout percentage mandatory in job configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,17 +181,18 @@ The `androidApkUpload` build step lets you upload Android App Bundle (AAB) or AP
 | googlePlayCredentialsId            | string  | My Google Play account | (none)                                                   | Name of the Google Service Account credential created in Jenkins                                                       |
 | filesPattern                       | string  | `'release/my-app.aab'` | `'**/build/outputs/**/*.aab, **/build/outputs/**/*.apk'` | Comma-separated glob patterns or filenames pointing to the app files to upload, relative to the root of the workspace  |
 | trackName                          | string  | `'internal'`           | (none)                                                   | Google Play track to which the app files should be published                                                           |
-| rolloutPercentage                  | string  | `'1.5'`                | `'100%'`                                                 | The rollout percentage to set on the track; use 0% to create a draft release                                           |
-| ~rolloutPercent~<br>(deprecated)   | number  | `1.5`                  | `100.0`                                                  | (deprecated, but still supported; prefer `rolloutPercentage` instead — it takes priority if both are defined)          |
+| rolloutPercentage                  | string  | `'1.5'`                | (none)                                                   | The rollout percentage to set on the track; use 0% to create a draft release                                           |
+| ~rolloutPercent~<br>(deprecated)   | number  | `1.5`                  | (none)                                                   | (deprecated, but still supported; prefer `rolloutPercentage` instead — it takes priority if both are defined)          |
 | deobfuscationFiles<br>Pattern      | string  | `'**/mapping.txt'`     | (none)                                                   | Comma-separated glob patterns or filenames pointing to ProGuard mapping files to associate with the uploaded app files |
 | expansionFilesPattern              | string  | `'**/*.obb'`           | (none)                                                   | Comma-separated glob patterns or filenames pointing to expansion files to associate with the uploaded APK files        |
 | usePreviousExpansion<br>FilesIfMissing | boolean | `false`            | `true`                                                   | Whether to re-use the existing expansion files that have already been uploaded to Google Play for this app, if any expansion files are missing |
 | recentChangeList                   | list    | (see below)            | (empty)                                                  | List of recent change texts to associate with the upload app files                                                     |
 
-The only mandatory parameters are `googlePlayCredentialsId` and `trackName`, e.g.:
+The `googlePlayCredentialsId`, `trackName`, and `rolloutPercentage` parameters are mandatory, e.g. a minimal configuration would be:
 ```groovy
 androidApkUpload googleCredentialsId: 'My Google Play account',
-                 trackName: 'production'
+                 trackName: 'production',
+                 rolloutPercentage: '100'
 ```
 
 This will find any app files in the workspace matching the pattern `**/build/outputs/**/*.aab, **/build/outputs/**/*.apk`, upload them to the Production track, and make them available to 100% of users.
@@ -218,25 +219,26 @@ androidApkUpload googleCredentialsId: 'My Google Play account',
 ```
 
 ##### Updating release tracks with existing app versions
-The `androidApkMove` build step lets you move existing Android app versions to another release track, and/or update the rollout percentage.
+The `androidApkMove` build step lets you move existing Android app versions (whether AAB or APK) to another release track, and/or update the rollout percentage.
 
 | Parameter               | Type    | Example                | Default                                                  | Description                                                                                                                     |
 |-------------------------|---------|------------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
 | googlePlayCredentialsId | string  | My Google Play account | (none)                                                   | Name of the Google Service Account credential created in Jenkins                                                                |
 | trackName               | string  | `'internal'`           | (none)                                                   | Google Play release track to update with the given app versions                                                                 |
-| rolloutPercentage       | string  | `'1.5'`                | `'100%'`                                                 | The rollout percentage to set on the given release track; use 0% to create a draft release                                      |
-| ~rolloutPercent~<br>(deprecated) | number  | `1.5`         | `100.0`                                                  | (deprecated, but still supported; prefer `rolloutPercentage` instead — it takes priority if both are defined)                   |
+| rolloutPercentage       | string  | `'1.5'`                | (none)                                                   | The rollout percentage to set on the given release track; use 0% to create a draft release                                      |
+| ~rolloutPercent~<br>(deprecated) | number  | `1.5`         | (none)                                                   | (deprecated, but still supported; prefer `rolloutPercentage` instead — it takes priority if both are defined)                   |
 | fromVersionCode         | boolean | `true`                 | `false`                                                  | If true, the `applicationId` and `versionCodes` parameters will be used. Otherwise the `filesPattern` parameter will be used    |
 | applicationId           | string  | `'com.example.app'`    | (none)                                                   | The application ID of the app to update                                                                                         |
 | versionCodes            | string  | `'1281, 1282, 1283'`   | (none)                                                   | Comma-separated list of version codes to set on the given release track                                                         |
 | filesPattern            | string  | `'release/my-app.aab'` | `'**/build/outputs/**/*.aab, **/build/outputs/**/*.apk'` | Comma-separated glob patterns or filenames pointing to the files from which the application ID and version codes should be read |
 
-The `googlePlayCredentialsId` and `trackName` parameters are mandatory, plus either an application ID and version code(s), or AAB or APK file(s) to read this information from.
+The `googlePlayCredentialsId`, `trackName`, and `rolloutPercentage` parameters are mandatory, plus either an application ID and version code(s), or AAB or APK file(s) to read this information from.
 
 For example, this would move the given versions to the production track, and make them available to 100% of users:
 ```groovy
 androidApkMove googleCredentialsId: 'My Google Play account',
                trackName: 'production',
+               rolloutPercentage: '100',
                applicationId: 'com.example.app',
                versionCodes: '1281, 1282, 1283'
 ```
@@ -258,11 +260,13 @@ Version 3.0 of the plugin deprecated some parameters used by the build steps, bu
 In addition, version 3.0 introduced the default values shown in the tables above, so those parameters can optionally now be omitted.
 
 ##### Version 4.0
-**NOTE: This version makes it mandatory to configure a release track name.**
+**NOTE: This version makes it mandatory to configure a release track name, and the rollout percentage.**
 
 In order to avoid unintentionally publishing to Production — if you forget to provide a track name, or use a string parameter for the track name but accidentally leave it empty, for example — we made the release track name a mandatory field.
 
 If you have jobs configured without a track name, or without a `trackName` for Pipeline, you now need to set the track name to `'production'` to restore the previous behaviour.
+
+For similar reasons, the rollout percentage must be explicitly specified — it no longer defaults to 100%.
 
 Sorry for any inconvenience caused by this breaking change.
 
@@ -307,6 +311,13 @@ Version 4.0 of the plugin made it [mandatory](#version-40) to specify the desire
 If you're seeing this error, it means you were relying on the previous behaviour where not specifying a release track name would default to releasing to the Production track.
 
 To fix this, update any job configurations to explicitly set the track name to `'production'`.
+
+### Rollout percentage was not specified; this is now a mandatory parameter
+Version 4.0 of the plugin made it [mandatory](#version-40) to specify the desired rollout percentage.
+
+If you're seeing this error, it means you were relying on the previous behaviour where not specifying a rollout percentage would default to releasing to 100% of users in the given release track.
+
+To fix this, update any job configurations to explicitly set the rollout percentage to `'100'`.
 
 ## Frequently asked questions
 ### What if I want to upload APKs with multiple, different application IDs (i.e. build flavours)?

--- a/README.md
+++ b/README.md
@@ -252,6 +252,15 @@ androidApkMove googleCredentialsId: 'My Google Play account',
                apkFilesPattern: '**/*.apk'
 ```
 
+Or, say the current production release is rolled out to 10% of users, and we want to expand the rollout to 25% of users:
+```groovy
+androidApkMove googleCredentialsId: 'My Google Play account',
+               trackName: 'production',
+               rolloutPercentage: '25',
+               applicationId: 'com.example.app',
+               versionCodes: '1281, 1282, 1283'
+```
+
 #### Backwards-compatibility
 ##### Version 3.0
 Version 3.0 of the plugin deprecated some parameters used by the build steps, but they will remain supported for the foreseeable future:

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
@@ -605,7 +605,6 @@ public class ApkPublisher extends GooglePlayPublisher {
     @Extension
     public static final class DescriptorImpl extends GooglePlayBuildStepDescriptor<Publisher> {
         public static final String defaultFilesPattern = "**/build/outputs/**/*.aab, **/build/outputs/**/*.apk";
-        public static final int defaultRolloutPercentage = 100;
 
         public String getDisplayName() {
             return "Upload Android AAB/APKs to Google Play";

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
@@ -133,19 +133,12 @@ public class ApkPublisher extends GooglePlayPublisher {
             this.rolloutPercentage = percentage;
             return;
         }
-        this.rolloutPercentage = pct.intValue() == DescriptorImpl.defaultRolloutPercentage ? null : pctStr;
+        this.rolloutPercentage = pctStr;
     }
 
-    @Nonnull
+    @Nullable
     public String getRolloutPercentage() {
-        String pct = fixEmptyAndTrim(rolloutPercentage);
-        if (pct == null) {
-            pct = String.valueOf(DescriptorImpl.defaultRolloutPercentage);
-        }
-        if (!pct.endsWith("%") && !pct.matches(REGEX_VARIABLE)) {
-            pct += "%";
-        }
-        return pct;
+        return fixEmptyAndTrim(rolloutPercentage);
     }
 
     // Required for Pipeline builds using the deprecated `rolloutPercent` option
@@ -235,17 +228,18 @@ public class ApkPublisher extends GooglePlayPublisher {
         return expand(getExpansionFilesPattern());
     }
 
+    @Nullable
     private String getExpandedRolloutPercentageString() throws IOException, InterruptedException {
         return expand(getRolloutPercentage());
     }
 
+    @SuppressWarnings("ConstantConditions")
     private double getExpandedRolloutPercentage() throws IOException, InterruptedException {
-        try {
-            String value = getExpandedRolloutPercentageString().replace("%", "").trim();
-            return Double.parseDouble(value);
-        } catch (NumberFormatException e) {
+        final String pctStr = getExpandedRolloutPercentageString();
+        if (pctStr == null) {
             return Double.NaN;
         }
+        return tryParseNumber(pctStr.replace("%", "").trim(), Double.NaN).doubleValue();
     }
 
     private RecentChanges[] getExpandedRecentChangesList() throws IOException, InterruptedException {
@@ -272,11 +266,16 @@ public class ApkPublisher extends GooglePlayPublisher {
         final String trackName = getCanonicalTrackName();
         if (trackName == null) {
             errors.add("Release track was not specified; this is now a mandatory parameter");
+        }
+
+        // Check for valid rollout percentage
+        final String pctStr = getExpandedRolloutPercentageString();
+        if (pctStr == null) {
+            errors.add("Rollout percentage was not specified; this is now a mandatory parameter");
         } else {
-            // Check for valid rollout percentage
             double pct = getExpandedRolloutPercentage();
             if (Double.isNaN(pct) || Double.compare(pct, 0) < 0 || Double.compare(pct, 100) > 0) {
-                errors.add(String.format("'%s' is not a valid rollout percentage", getExpandedRolloutPercentageString()));
+                errors.add(String.format("'%s' is not a valid rollout percentage", pctStr));
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
@@ -234,6 +234,7 @@ public class ApkPublisher extends GooglePlayPublisher {
     }
 
     @SuppressWarnings("ConstantConditions")
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private double getExpandedRolloutPercentage() throws IOException, InterruptedException {
         final String pctStr = getExpandedRolloutPercentageString();
         if (pctStr == null) {

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/GooglePlayBuildStepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/GooglePlayBuildStepDescriptor.java
@@ -93,7 +93,10 @@ public abstract class GooglePlayBuildStepDescriptor<T extends BuildStep & Descri
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public FormValidation doCheckRolloutPercentage(@QueryParameter String value) {
         value = fixEmptyAndTrim(value);
-        if (value == null || value.matches(REGEX_VARIABLE)) {
+        if (value == null) {
+            return FormValidation.error("A rollout percentage is required");
+        }
+        if (value.matches(REGEX_VARIABLE)) {
             return FormValidation.ok();
         }
 

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/GooglePlayPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/GooglePlayPublisher.java
@@ -11,6 +11,7 @@ import jenkins.tasks.SimpleBuildStep;
 import org.kohsuke.stapler.DataBoundSetter;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 
 @RequiresDomain(value = AndroidPublisherScopeRequirement.class)
@@ -49,6 +50,7 @@ public abstract class GooglePlayPublisher extends Recorder implements SimpleBuil
     }
 
     /** @return An expanded value, using the build and environment variables, plus token macro expansion. */
+    @Nullable
     protected String expand(String value) throws IOException, InterruptedException {
         return Util.expand(currentBuild.get(), currentListener.get(), value);
     }

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
@@ -142,19 +142,12 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
             this.rolloutPercentage = percentage;
             return;
         }
-        this.rolloutPercentage = pct.intValue() == DescriptorImpl.defaultRolloutPercentage ? null : pctStr;
+        this.rolloutPercentage = pctStr;
     }
 
-    @Nonnull
+    @Nullable
     public String getRolloutPercentage() {
-        String pct = fixEmptyAndTrim(rolloutPercentage);
-        if (pct == null) {
-            pct = String.valueOf(ApkPublisher.DescriptorImpl.defaultRolloutPercentage);
-        }
-        if (!pct.endsWith("%") && !pct.matches(REGEX_VARIABLE)) {
-            pct += "%";
-        }
-        return pct;
+        return fixEmptyAndTrim(rolloutPercentage);
     }
 
     // Required for Pipeline builds using the deprecated `rolloutPercent` option
@@ -202,17 +195,18 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
         return expand(getTrackName());
     }
 
+    @Nullable
     private String getExpandedRolloutPercentageString() throws IOException, InterruptedException {
         return expand(getRolloutPercentage());
     }
 
+    @SuppressWarnings("ConstantConditions")
     private double getExpandedRolloutPercentage() throws IOException, InterruptedException {
-        try {
-            String value = getExpandedRolloutPercentageString().replace("%", "").trim();
-            return Double.parseDouble(value);
-        } catch (NumberFormatException e) {
+        final String pctStr = getExpandedRolloutPercentageString();
+        if (pctStr == null) {
             return Double.NaN;
         }
+        return tryParseNumber(pctStr.replace("%", "").trim(), Double.NaN).doubleValue();
     }
 
     private boolean isConfigValid(PrintStream logger) throws IOException, InterruptedException {
@@ -234,11 +228,16 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
         final String trackName = getCanonicalTrackName();
         if (trackName == null) {
             errors.add("Release track was not specified; this is now a mandatory parameter");
+        }
+
+        // Check for valid rollout percentage
+        final String pctStr = getExpandedRolloutPercentageString();
+        if (pctStr == null) {
+            errors.add("Rollout percentage was not specified; this is now a mandatory parameter");
         } else {
-            // Check for valid rollout percentage
             double pct = getExpandedRolloutPercentage();
             if (Double.isNaN(pct) || Double.compare(pct, 0) < 0 || Double.compare(pct, 100) > 0) {
-                errors.add(String.format("'%s' is not a valid rollout percentage", getExpandedRolloutPercentageString()));
+                errors.add(String.format("'%s' is not a valid rollout percentage", pctStr));
             }
         }
 
@@ -364,7 +363,6 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
     @Extension
     public static final class DescriptorImpl extends GooglePlayBuildStepDescriptor<Builder> {
         public static final String defaultFilesPattern = "**/build/outputs/**/*.aab, **/build/outputs/**/*.apk";
-        public static final int defaultRolloutPercentage = 100;
 
         public String getDisplayName() {
             return "Move Android apps to a different release track";

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
@@ -201,6 +201,7 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
     }
 
     @SuppressWarnings("ConstantConditions")
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private double getExpandedRolloutPercentage() throws IOException, InterruptedException {
         final String pctStr = getExpandedRolloutPercentageString();
         if (pctStr == null) {

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/Util.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/Util.java
@@ -59,6 +59,7 @@ public class Util {
     }
 
     /** @return The given value with variables expanded and trimmed; {@code null} if that results in an empty string. */
+    @Nullable
     static String expand(Run<?, ?> run, TaskListener listener, String value)
             throws InterruptedException, IOException {
         // If this is a pipeline run, there's no need to expand tokens

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
@@ -25,9 +25,8 @@
     <f:combobox style="width:15em" />
   </f:entry>
 
-  <f:entry title="${%Rollout %}" field="rolloutPercentage"
-      description="${%Defaults to 100% if not set}">
-    <f:textbox style="width:15em" default="${descriptor.defaultRolloutPercentage}%" />
+  <f:entry title="${%Rollout %}" field="rolloutPercentage">
+    <f:textbox style="width:15em" />
   </f:entry>
 
   <f:entry title="${%Recent changes}" field="recentChangeList">

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-rolloutPercentage.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-rolloutPercentage.html
@@ -2,7 +2,8 @@
   The percentage of users in the given track to which the uploaded file(s)
   should be rolled out.
   <p/>
-  If you enter no value here, or 100%, the app will be rolled out to all users.
+  If you enter 100%, the app will be rolled out to all users, and the release will be considered complete,
+  i.e. you will be unable to reduce the rollout percentage for this release.
   <p/>
   If you enter 0%, a draft release will be created, meaning that users will not yet see it;
   the existing file(s) released in the given track, if any, will remain in place.

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/config.jelly
@@ -33,9 +33,8 @@
     <f:combobox style="width:15em" />
   </f:entry>
 
-  <f:entry title="${%Rollout %}" field="rolloutPercentage"
-      description="${%Defaults to 100% if not set}">
-    <f:textbox style="width:15em" default="${descriptor.defaultRolloutPercentage}%" />
+  <f:entry title="${%Rollout %}" field="rolloutPercentage">
+    <f:textbox style="width:15em" />
   </f:entry>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/help-rolloutPercentage.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/help-rolloutPercentage.html
@@ -2,7 +2,8 @@
   The percentage of users in the given track to which the uploaded file(s)
   should be rolled out.
   <p/>
-  If you enter no value here, or 100%, the app will be rolled out to all users.
+  If you enter 100%, the app will be rolled out to all users, and the release will be considered complete,
+  i.e. you will be unable to reduce the rollout percentage for this release.
   <p/>
   If you enter 0%, a draft release will be created, meaning that users will not yet see it;
   the existing file(s) released in the given track, if any, will remain in place.

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
@@ -111,10 +111,10 @@ public class ApkPublisherTest {
         publisher.setGoogleCredentialsId("credential-b");
         publisher.setFilesPattern("**/builds/*.apk, *.aab");
         publisher.setDeobfuscationFilesPattern("**/proguard/*.txt");
-        publisher.setExpansionFilesPattern("**/exp/*.obb");
+        publisher.setExpansionFilesPattern("${EXP_FILES}");
         publisher.setUsePreviousExpansionFilesIfMissing(true);
         publisher.setTrackName("alpha");
-        publisher.setRolloutPercentage("${ROLLOUT}");
+        publisher.setRolloutPercentage("12.3456789");
         publisher.setRecentChangeList(new ApkPublisher.RecentChanges[] {
             new ApkPublisher.RecentChanges("en", "Hello!"),
             new ApkPublisher.RecentChanges("de", "Hallo!"),
@@ -152,6 +152,7 @@ public class ApkPublisherTest {
         ApkPublisher publisher = new ApkPublisher();
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setTrackName("");
+        publisher.setRolloutPercentage("100");
         p.getPublishersList().add(publisher);
 
         // And the prerequisites are in place
@@ -165,12 +166,72 @@ public class ApkPublisherTest {
     }
 
     @Test
+    public void uploadingWithoutRolloutPercentageFails() throws Exception {
+        // Given a job where the rollout percentage is not provided
+        FreeStyleProject p = j.createFreeStyleProject();
+        ApkPublisher publisher = new ApkPublisher();
+        publisher.setGoogleCredentialsId("test-credentials");
+        publisher.setTrackName("production");
+        p.getPublishersList().add(publisher);
+
+        // And the prerequisites are in place
+        setUpCredentials("test-credentials");
+        setUpTransportForApk();
+        setUpApkFile(p);
+
+        // When a build occurs
+        // Then it should fail as the rollout percentage has not been specified
+        assertResultWithLogLines(j, p, Result.FAILURE, "Rollout percentage was not specified");
+    }
+
+    @Test
+    public void uploadingWithEmptyRolloutPercentageFails() throws Exception {
+        // Given a job where the percentage is empty (e.g. saved without entering a value, or an empty parameter value)
+        FreeStyleProject p = j.createFreeStyleProject();
+        ApkPublisher publisher = new ApkPublisher();
+        publisher.setGoogleCredentialsId("test-credentials");
+        publisher.setTrackName("production");
+        publisher.setRolloutPercentage("");
+        p.getPublishersList().add(publisher);
+
+        // And the prerequisites are in place
+        setUpCredentials("test-credentials");
+        setUpTransportForApk();
+        setUpApkFile(p);
+
+        // When a build occurs
+        // Then it should fail as the rollout percentage has not been specified
+        assertResultWithLogLines(j, p, Result.FAILURE, "Rollout percentage was not specified");
+    }
+
+    @Test
+    public void uploadingWithInvalidRolloutPercentageFails() throws Exception {
+        // Given a job where the rollout percentage can't be parsed
+        FreeStyleProject p = j.createFreeStyleProject();
+        ApkPublisher publisher = new ApkPublisher();
+        publisher.setGoogleCredentialsId("test-credentials");
+        publisher.setTrackName("production");
+        publisher.setRolloutPercentage("everyone");
+        p.getPublishersList().add(publisher);
+
+        // And the prerequisites are in place
+        setUpCredentials("test-credentials");
+        setUpTransportForApk();
+        setUpApkFile(p);
+
+        // When a build occurs
+        // Then it should fail as the rollout percentage is not valid
+        assertResultWithLogLines(j, p, Result.FAILURE, "'everyone' is not a valid rollout percentage");
+    }
+
+    @Test
     public void uploadingWithoutMatchingFilesFails() throws Exception {
         // Given a job with the default configuration
         FreeStyleProject p = j.createFreeStyleProject();
         ApkPublisher publisher = new ApkPublisher();
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setTrackName("production");
+        publisher.setRolloutPercentage("100");
         p.getPublishersList().add(publisher);
 
         // And the prerequisites are in place
@@ -200,6 +261,7 @@ public class ApkPublisherTest {
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setFilesPattern("**/*.apk");
         publisher.setTrackName("production");
+        publisher.setRolloutPercentage("100");
         p.getPublishersList().add(publisher);
 
         setUpCredentials("test-credentials");
@@ -228,6 +290,7 @@ public class ApkPublisherTest {
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setFilesPattern("**/*.apk");
         publisher.setTrackName("production");
+        publisher.setRolloutPercentage("100");
 
         p.getPublishersList().add(publisher);
 
@@ -268,11 +331,12 @@ public class ApkPublisherTest {
 
     @Test
     public void uploadingApkWithMinimalConfigurationUsesDefaults() throws Exception {
-        // Given a job, whose publisher has a credential and track name, but no other configuration
+        // Given a job, whose publisher has a credential, track name, and rollout percentage, but no other configuration
         FreeStyleProject p = j.createFreeStyleProject();
         ApkPublisher publisher = new ApkPublisher();
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setTrackName("production");
+        publisher.setRolloutPercentage("100");
         p.getPublishersList().add(publisher);
 
         // And the prerequisites are in place
@@ -303,6 +367,7 @@ public class ApkPublisherTest {
         publisher.setGoogleCredentialsId("folder-credentials");
         publisher.setFilesPattern("**/*.apk");
         publisher.setTrackName("production");
+        publisher.setRolloutPercentage("100");
         p.getPublishersList().add(publisher);
         setUpApkFile(p);
 
@@ -414,12 +479,36 @@ public class ApkPublisherTest {
     }
 
     @Test
+    public void uploadingApkWithPipelineWithoutRolloutPercentageFails() throws Exception {
+        // Given a Pipeline where the rollout percentage is not provided
+        String stepDefinition = "androidApkUpload googleCredentialsId: 'test-credentials',\n" +
+                "  trackName: 'production'";
+
+        // When a build occurs
+        // Then it should fail as the rollout percentage has not been specified
+        uploadApkWithPipelineAndAssertFailure(stepDefinition, "Rollout percentage was not specified");
+    }
+
+    @Test
+    public void uploadingApkWithPipelineWithEmptyRolloutPercentageFails() throws Exception {
+        // Given a Pipeline where the rollout percentage is empty (e.g. an empty parameter value)
+        String stepDefinition = "androidApkUpload googleCredentialsId: 'test-credentials',\n" +
+                "  trackName: 'production',\n" +
+                "  rolloutPercentage: ''";
+
+        // When a build occurs
+        // Then it should fail as the rollout percentage has not been specified
+        uploadApkWithPipelineAndAssertFailure(stepDefinition, "Rollout percentage was not specified");
+    }
+
+    @Test
     public void uploadingApkToCustomTrackSucceeds() throws Exception {
         // Given a job, whose publisher wants to upload to a custom release track
         FreeStyleProject p = j.createFreeStyleProject();
         ApkPublisher publisher = new ApkPublisher();
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setTrackName("DogFood"); // case should not matter
+        publisher.setRolloutPercentage("100");
         p.getPublishersList().add(publisher);
 
         // And the prerequisites are in place
@@ -443,6 +532,7 @@ public class ApkPublisherTest {
         ApkPublisher publisher = new ApkPublisher();
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setTrackName("dogfood");
+        publisher.setRolloutPercentage("100");
         p.getPublishersList().add(publisher);
 
         // And the prerequisites are in place
@@ -470,6 +560,7 @@ public class ApkPublisherTest {
         ApkPublisher publisher = new ApkPublisher();
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setTrackName("non-existent-track");
+        publisher.setRolloutPercentage("100");
         p.getPublishersList().add(publisher);
 
         // And the prerequisites are in place
@@ -486,26 +577,12 @@ public class ApkPublisherTest {
     public void uploadingApkWithPipelineSucceeds() throws Exception {
         // Given a Pipeline with only the required parameters
         String stepDefinition = "androidApkUpload googleCredentialsId: 'test-credentials',\n" +
-                "  trackName: 'production'";
+                "  trackName: 'production',\n" +
+                "  rolloutPercentage: '100'";
 
         uploadApkWithPipelineAndAssertSuccess(
             stepDefinition,
             "Setting rollout to target 100% of 'production' track users",
-            "The 'production' release track will now contain the version code(s): 42"
-        );
-    }
-
-    @Test
-    public void uploadingApkWithPipelineWithRolloutPercentageSucceeds() throws Exception {
-        // Given a step with a `rolloutPercentage` value
-        String stepDefinition = "androidApkUpload googleCredentialsId: 'test-credentials',\n" +
-                "  trackName: 'production',\n" +
-                "  rolloutPercentage: '56.789'";
-
-        // When a build occurs, it should roll out to that percentage
-        uploadApkWithPipelineAndAssertSuccess(
-            stepDefinition,
-            "Setting rollout to target 56.789% of 'production' track users",
             "The 'production' release track will now contain the version code(s): 42"
         );
     }
@@ -567,7 +644,8 @@ public class ApkPublisherTest {
     public void uploadingApkWithPipelineToCustomTrackSucceeds() throws Exception {
         // Given a step that wants to upload to a custom release track
         String stepDefinition = "androidApkUpload googleCredentialsId: 'test-credentials',\n" +
-                "  trackName: 'dogfood'";
+                "  trackName: 'dogfood',\n" +
+                "  rolloutPercentage: '100'";
 
         // And the backend will recognise the custom track
         setUpTransportForApk("dogfood");
@@ -586,7 +664,9 @@ public class ApkPublisherTest {
         // Given a step that wants to upload to a custom release track
         // But the track does not exist on the backend
         String stepDefinition = "androidApkUpload googleCredentialsId: 'test-credentials',\n" +
-                "  trackName: 'non-existent-track'";
+                "  trackName: 'non-existent-track',\n" +
+                "  rolloutPercentage: '100'";
+
 
         // And the backend does not know about the custom track
         setUpTransportForApk();
@@ -650,6 +730,7 @@ public class ApkPublisherTest {
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setFilesPattern("**/*.aab");
         publisher.setTrackName("production");
+        publisher.setRolloutPercentage("100");
         p.getPublishersList().add(publisher);
 
         setUpCredentials("test-credentials");
@@ -678,6 +759,7 @@ public class ApkPublisherTest {
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setFilesPattern("**/*.aab");
         publisher.setTrackName("production");
+        publisher.setRolloutPercentage("100");
 
         p.getPublishersList().add(publisher);
 
@@ -717,6 +799,7 @@ public class ApkPublisherTest {
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setFilesPattern("**/*");
         publisher.setTrackName("production");
+        publisher.setRolloutPercentage("100");
         p.getPublishersList().add(publisher);
 
         setUpCredentials("test-credentials");
@@ -749,7 +832,8 @@ public class ApkPublisherTest {
                 "node {\n" +
                 "  writeFile text: 'this-is-a-dummy-bundle', file: 'build/outputs/bundle/release/bundle.aab'\n" +
                 "  androidApkUpload googleCredentialsId: 'test-credentials',\n" + //
-                "                   trackName: 'production'\n" +
+                "                   trackName: 'production',\n" +
+                "                   rolloutPercentage: '100'\n" +
                 "}", true
         ));
 
@@ -810,6 +894,7 @@ public class ApkPublisherTest {
         publisher.setGoogleCredentialsId("test-credentials");
         publisher.setFilesPattern("**/*.apk");
         publisher.setTrackName("production");
+        publisher.setRolloutPercentage("100");
 
         p.getPublishersList().add(publisher);
 


### PR DESCRIPTION
**Ticket:**
https://issues.jenkins-ci.org/browse/JENKINS-62516

**Description:**
Similar to #33, removed `100%` as the default rollout percentage for the build steps.
⚠️ This is a breaking change, which will require users to explicitly provide the rollout percentage.

i.e. users will have to update their Freestyle and Pipeline job configurations, e.g.:
```diff
   // Upload to 100% of users in Production
   androidApkUpload googlePlayCredentialsId: 'gp',
-                   trackName: 'production'
   androidApkUpload googlePlayCredentialsId: 'gp',
+                   trackName: 'production',
+                   rolloutPercentage: '100'
```

Without this change, if no rollout percentage is specified, they'll see this in the build console log:
> Rollout percentage was not specified; this is now a mandatory parameter

This change makes the plugin safer, as publishing to 100% of users by default, e.g. in the absence of configuration, or due to a mistake when defining a parameter, is probably unexpected behaviour for most users.

The README has been updated with information on the breaking change, and I'll make this clear in the CHANGELOG at the next release. I wonder whether to also [mark the plugin](https://wiki.jenkins.io/display/JENKINS/Marking+a+new+plugin+version+as+incompatible+with+older+versions)  as "incompatible".

**Testing:**
Added automated tests, and did some manual testing of the config UI, snippet generator, and running builds.