### PR TITLE
Add InAppUpdatePrioritySupport

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Enables Jenkins to manage and upload Android app files (AAB or APK) to Google Pl
 - Uploading Android App Bundle (AAB) or APK files to Google Play
   - This includes apps which use Multiple APK support
   - ProGuard `mapping.txt` files can also be associated with each app file, for deobfuscating stacktraces
+  - The update priority can also be set, if using [in-app updates][gp-docs-inappupdates]
 -  Uploading APK expansion (.obb) files
    - With the option to re-use expansion files from existing APKs, e.g. for patch releases
 - Assigning apps to internal, alpha, beta, production, or custom release tracks
@@ -22,7 +23,6 @@ Enables Jenkins to manage and upload Android app files (AAB or APK) to Google Pl
 -  Every configuration field supports variable and [token][plugin-token-macro] expansion, allowing release notes to be dynamically generated, for example
 - Integration with the [Google OAuth Credentials Plugin][plugin-google-oauth], so that Google Play credentials can be entered once globally, stored securely, and shared between jobs
   - Multiple Google Play accounts are also supported via this mechanism
-- Set the inAppUpdatePriority
 
 ## Requirements
 ### Jenkins
@@ -147,9 +147,8 @@ The following job setup process is demonstrated in this video:
    - If 0% is entered, the given file(s) will be uploaded as a draft release, leaving any existing rollout unaffected
 8. Optionally choose "Add language" to associate release notes with the uploaded APK(s)
    - You add entries for as many or as few of your supported language as you wish, but each language must already have been added to your app, under the "Store Listing" section in the Google Play Developer Console.
-9. Optionally specify [inAppUpdatePriority][gp-docs-inappupdatepriority]
-   - If nothing is entered, nothing it uses the default value of Google Play API
-   - This should be a valid Integer
+9. Optionally specify an [in-app update priority][gp-docs-inappupdatepriority]
+   - If nothing is entered, the default value (0, lowest priority) will be set by Google Play
 
 ###### APK expansion files
 You can optionally add up to two [expansion files][gp-docs-expansions] (main + patch) for each APK being uploaded.
@@ -191,7 +190,7 @@ The `androidApkUpload` build step lets you upload Android App Bundle (AAB) or AP
 | expansionFilesPattern              | string  | `'**/*.obb'`           | (none)                                                   | Comma-separated glob patterns or filenames pointing to expansion files to associate with the uploaded APK files        |
 | usePreviousExpansion<br>FilesIfMissing | boolean | `false`            | `true`                                                   | Whether to re-use the existing expansion files that have already been uploaded to Google Play for this app, if any expansion files are missing |
 | recentChangeList                   | list    | (see below)            | (empty)                                                  | List of recent change texts to associate with the upload app files                                                     |
-| inAppUpdatePriority                | string  | `'1'`                  | (none)                                                   | Priority used for In-App update feature                                                                                |
+| inAppUpdatePriority                | string  | `'1'`                  | `'0'`                                                    | Priority of this release, used by the Google Play Core in-app update feature                                           |
 
 The only mandatory parameters are `googlePlayCredentialsId` and `trackName`, e.g.:
 ```groovy
@@ -236,7 +235,7 @@ The `androidApkMove` build step lets you move existing Android app versions to a
 | applicationId           | string  | `'com.example.app'`    | (none)                                                   | The application ID of the app to update                                                                                         |
 | versionCodes            | string  | `'1281, 1282, 1283'`   | (none)                                                   | Comma-separated list of version codes to set on the given release track                                                         |
 | filesPattern            | string  | `'release/my-app.aab'` | `'**/build/outputs/**/*.aab, **/build/outputs/**/*.apk'` | Comma-separated glob patterns or filenames pointing to the files from which the application ID and version codes should be read |
-| inAppUpdatePriority     | string  | `'1'`                  | (none)                                                   | Priority used for In-App update feature                                                                                         |
+| inAppUpdatePriority     | string  | `'1'`                  | `'0'`                                                    | Priority of this release, used by the Google Play Core in-app update feature                                           |
 
 The `googlePlayCredentialsId` and `trackName` parameters are mandatory, plus either an application ID and version code(s), or AAB or APK file(s) to read this information from.
 
@@ -357,9 +356,10 @@ See [CHANGELOG.md][changelog].
 [gp-console-admin]:https://play.google.com/apps/publish/#AdminPlace
 [gp-docs-distribute]:https://developer.android.com/distribute/best-practices/launch
 [gp-docs-expansions]:https://developer.android.com/google/play/expansion-files.html
+[gp-docs-inappupdatepriority]:https://developer.android.com/guide/playcore/in-app-updates#check-priority
+[gp-docs-inappupdates]:https://developer.android.com/guide/playcore/in-app-updates
 [gp-docs-rollout]:https://support.google.com/googleplay/android-developer/answer/6346149
 [gp-support-form]:https://support.google.com/googleplay/android-developer/contact/publishing?extra.IssueType=submitting&hl=en&ec=publish&cfsi=publish_cf&cfnti=escalationflow.email&cft=3&rd=1
-[gp-docs-inappupdatepriority]:https://developer.android.com/guide/playcore/in-app-updates?authuser=2#check-priority
 [issues-existing]:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20component%20%3D%20google-play-android-publisher-plugin%20AND%20status%20NOT%20IN(Closed%2C%20Resolved)%20ORDER%20BY%20updated%20DESC
 [issues-report]:http://jenkins.io/redirect/report-an-issue
 [jenkins-behind-proxy]:https://wiki.jenkins.io/display/JENKINS/JenkinsBehindProxy#JenkinsBehindProxy-HowJenkinshandlesProxyServers

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Enables Jenkins to manage and upload Android app files (AAB or APK) to Google Pl
 -  Every configuration field supports variable and [token][plugin-token-macro] expansion, allowing release notes to be dynamically generated, for example
 - Integration with the [Google OAuth Credentials Plugin][plugin-google-oauth], so that Google Play credentials can be entered once globally, stored securely, and shared between jobs
   - Multiple Google Play accounts are also supported via this mechanism
+- Set the inAppUpdatePriority
 
 ## Requirements
 ### Jenkins
@@ -146,6 +147,9 @@ The following job setup process is demonstrated in this video:
    - If 0% is entered, the given file(s) will be uploaded as a draft release, leaving any existing rollout unaffected
 8. Optionally choose "Add language" to associate release notes with the uploaded APK(s)
    - You add entries for as many or as few of your supported language as you wish, but each language must already have been added to your app, under the "Store Listing" section in the Google Play Developer Console.
+9. Optionally specify [inAppUpdatePriority][gp-docs-rollout]
+   - If nothing is entered, nothing it uses the default value of Google Play API
+   - This should be a valid Integer
 
 ###### APK expansion files
 You can optionally add up to two [expansion files][gp-docs-expansions] (main + patch) for each APK being uploaded.
@@ -187,6 +191,7 @@ The `androidApkUpload` build step lets you upload Android App Bundle (AAB) or AP
 | expansionFilesPattern              | string  | `'**/*.obb'`           | (none)                                                   | Comma-separated glob patterns or filenames pointing to expansion files to associate with the uploaded APK files        |
 | usePreviousExpansion<br>FilesIfMissing | boolean | `false`            | `true`                                                   | Whether to re-use the existing expansion files that have already been uploaded to Google Play for this app, if any expansion files are missing |
 | recentChangeList                   | list    | (see below)            | (empty)                                                  | List of recent change texts to associate with the upload app files                                                     |
+| inAppUpdatePriority                | string  | `'1'`                  | (none)                                                   | Priority used for In-App update feature                                                                                |
 
 The only mandatory parameters are `googlePlayCredentialsId` and `trackName`, e.g.:
 ```groovy
@@ -206,7 +211,8 @@ androidApkUpload googleCredentialsId: 'My Google Play account',
                  recentChangeList: [
                    [language: 'en-GB', text: "Please test the changes from Jenkins build ${env.BUILD_NUMBER}."],
                    [language: 'de-DE', text: "Bitte die Änderungen vom Jenkins Build ${env.BUILD_NUMBER} testen."]
-                 ]
+                 ],
+                 inAppUpdatePriority: '2'
 ```
 
 To upload APKs and their expansion files, reusing those from the previous upload where possible:
@@ -230,6 +236,7 @@ The `androidApkMove` build step lets you move existing Android app versions to a
 | applicationId           | string  | `'com.example.app'`    | (none)                                                   | The application ID of the app to update                                                                                         |
 | versionCodes            | string  | `'1281, 1282, 1283'`   | (none)                                                   | Comma-separated list of version codes to set on the given release track                                                         |
 | filesPattern            | string  | `'release/my-app.aab'` | `'**/build/outputs/**/*.aab, **/build/outputs/**/*.apk'` | Comma-separated glob patterns or filenames pointing to the files from which the application ID and version codes should be read |
+| inAppUpdatePriority     | string  | `'1'`                  | (none)                                                   | Priority used for In-App update feature                                                                                         |
 
 The `googlePlayCredentialsId` and `trackName` parameters are mandatory, plus either an application ID and version code(s), or AAB or APK file(s) to read this information from.
 
@@ -352,6 +359,7 @@ See [CHANGELOG.md][changelog].
 [gp-docs-expansions]:https://developer.android.com/google/play/expansion-files.html
 [gp-docs-rollout]:https://support.google.com/googleplay/android-developer/answer/6346149
 [gp-support-form]:https://support.google.com/googleplay/android-developer/contact/publishing?extra.IssueType=submitting&hl=en&ec=publish&cfsi=publish_cf&cfnti=escalationflow.email&cft=3&rd=1
+[gp-docs-inappupdatepriority]:https://developer.android.com/guide/playcore/in-app-updates?authuser=2#check-priority
 [issues-existing]:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20component%20%3D%20google-play-android-publisher-plugin%20AND%20status%20NOT%20IN(Closed%2C%20Resolved)%20ORDER%20BY%20updated%20DESC
 [issues-report]:http://jenkins.io/redirect/report-an-issue
 [jenkins-behind-proxy]:https://wiki.jenkins.io/display/JENKINS/JenkinsBehindProxy#JenkinsBehindProxy-HowJenkinshandlesProxyServers

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ The following job setup process is demonstrated in this video:
    - If 0% is entered, the given file(s) will be uploaded as a draft release, leaving any existing rollout unaffected
 8. Optionally choose "Add language" to associate release notes with the uploaded APK(s)
    - You add entries for as many or as few of your supported language as you wish, but each language must already have been added to your app, under the "Store Listing" section in the Google Play Developer Console.
-9. Optionally specify [inAppUpdatePriority][gp-docs-rollout]
+9. Optionally specify [inAppUpdatePriority][gp-docs-inappupdatepriority]
    - If nothing is entered, nothing it uses the default value of Google Play API
    - This should be a valid Integer
 

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
@@ -309,10 +309,11 @@ public class ApkPublisher extends GooglePlayPublisher {
 
         // Check if inAppUpdatePriority is a valid number if not null
         if (inAppUpdatePriority != null) {
+            String expandedInAppUpdatePriorityStr = getExpandedInAppUpdatePriorityString();
             try {
-                Integer.parseInt(inAppUpdatePriority);
+                Integer.parseInt(expandedInAppUpdatePriorityStr);
             } catch (NumberFormatException e) {
-                errors.add(String.format("'%s' is not a valid inAppUpdatePriority", getExpandedInAppUpdatePriorityString()));
+                errors.add(String.format("'%s' is not a valid inAppUpdatePriority", expandedInAppUpdatePriorityStr));
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher.java
@@ -275,16 +275,15 @@ public class ApkPublisher extends GooglePlayPublisher {
         return expand(getInAppUpdatePriority());
     }
 
+    @SuppressWarnings("ConstantConditions")
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private Integer getExpandedInAppUpdatePriority() throws IOException, InterruptedException {
-        try {
-            String value = getExpandedInAppUpdatePriorityString();
-            if (value != null) {
-                return Integer.parseInt(value.trim());
-            }
-            return null;
-        } catch (NumberFormatException e) {
+        String prioStr = getExpandedInAppUpdatePriorityString();
+        int priority = tryParseNumber(prioStr, Integer.MIN_VALUE).intValue();
+        if (priority == Integer.MIN_VALUE) {
             return null;
         }
+        return priority;
     }
 
     private boolean isConfigValid(PrintStream logger) throws IOException, InterruptedException {
@@ -307,14 +306,9 @@ public class ApkPublisher extends GooglePlayPublisher {
             }
         }
 
-        // Check if inAppUpdatePriority is a valid number if not null
-        if (inAppUpdatePriority != null) {
-            String expandedInAppUpdatePriorityStr = getExpandedInAppUpdatePriorityString();
-            try {
-                Integer.parseInt(expandedInAppUpdatePriorityStr);
-            } catch (NumberFormatException e) {
-                errors.add(String.format("'%s' is not a valid inAppUpdatePriority", expandedInAppUpdatePriorityStr));
-            }
+        // Check whether in-app priority could be parsed to a number
+        if (getExpandedInAppUpdatePriorityString() != null && getExpandedInAppUpdatePriority() == null) {
+            errors.add(String.format("'%s' is not a valid update priority", getExpandedInAppUpdatePriorityString()));
         }
 
         // Print accumulated errors

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
@@ -51,8 +51,8 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
     ApkUploadTask(TaskListener listener, GoogleRobotCredentials credentials, String applicationId,
                   FilePath workspace, List<UploadFile> appFilesToUpload, Map<Long, ExpansionFileSet> expansionFiles,
                   boolean usePreviousExpansionFilesIfMissing, String trackName, double rolloutPercentage,
-                  ApkPublisher.RecentChanges[] recentChangeList) {
-        super(listener, credentials, applicationId, trackName, rolloutPercentage);
+                  ApkPublisher.RecentChanges[] recentChangeList, Integer inAppUpdatePriority) {
+        super(listener, credentials, applicationId, trackName, rolloutPercentage, inAppUpdatePriority);
         this.workspace = workspace;
         this.appFilesToUpload = appFilesToUpload;
         this.expansionFiles = expansionFiles;
@@ -175,9 +175,14 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
             }
         }
 
+        if (inAppUpdatePriority != null) {
+            logger.println(String.format("Set inAppUpdatePriority to %d", inAppUpdatePriority));
+        }
+
         // Assign all uploaded app files to the configured track
         List<LocalizedText> releaseNotes = Util.transformReleaseNotes(recentChangeList);
-        TrackRelease release = Util.buildRelease(uploadedVersionCodes, rolloutFraction, releaseNotes);
+        TrackRelease release =
+                Util.buildRelease(uploadedVersionCodes, rolloutFraction, inAppUpdatePriority, releaseNotes);
         assignAppFilesToTrack(trackName, rolloutFraction, release);
 
         // Commit all the changes

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
@@ -176,7 +176,7 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
         }
 
         if (inAppUpdatePriority != null) {
-            logger.println(String.format("Set inAppUpdatePriority to %d", inAppUpdatePriority));
+            logger.println(String.format("Setting in-app update priority to %d", inAppUpdatePriority));
         }
 
         // Assign all uploaded app files to the configured track

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/GooglePlayBuildStepDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/GooglePlayBuildStepDescriptor.java
@@ -83,6 +83,11 @@ public abstract class GooglePlayBuildStepDescriptor<T extends BuildStep & Descri
         return listBox;
     }
 
+    public ComboBoxModel doFillTrackNameItems() {
+        // Auto-complete the default track names, though users can also enter custom track names
+        return new ComboBoxModel("internal", "alpha", "beta", "production");
+    }
+
     public FormValidation doCheckTrackName(@QueryParameter String value) {
         if (fixEmptyAndTrim(value) == null) {
             return FormValidation.error("A release track is required");
@@ -90,6 +95,7 @@ public abstract class GooglePlayBuildStepDescriptor<T extends BuildStep & Descri
         return FormValidation.ok();
     }
 
+    @SuppressWarnings("ConstantConditions")
     @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     public FormValidation doCheckRolloutPercentage(@QueryParameter String value) {
         value = fixEmptyAndTrim(value);
@@ -104,9 +110,19 @@ public abstract class GooglePlayBuildStepDescriptor<T extends BuildStep & Descri
         return FormValidation.ok();
     }
 
-    public ComboBoxModel doFillTrackNameItems() {
-        // Auto-complete the default track names, though users can also enter custom track names
-        return new ComboBoxModel("internal", "alpha", "beta", "production");
+    @SuppressWarnings("ConstantConditions")
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
+    public FormValidation doCheckInAppUpdatePriority(@QueryParameter String value) {
+        value = fixEmptyAndTrim(value);
+        if (value == null || value.matches(REGEX_VARIABLE)) {
+            return FormValidation.ok();
+        }
+
+        int priority = tryParseNumber(value.trim(), -1).intValue();
+        if (priority < 0 || priority > 5) {
+            return FormValidation.error("Priority value must be between 0 and 5");
+        }
+        return FormValidation.ok();
     }
 
     public boolean isApplicable(Class<? extends AbstractProject> c) {

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
@@ -230,16 +230,15 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
         return expand(getInAppUpdatePriority());
     }
 
+    @SuppressWarnings("ConstantConditions")
+    @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
     private Integer getExpandedInAppUpdatePriority() throws IOException, InterruptedException {
-        try {
-            String value = getExpandedInAppUpdatePriorityString();
-            if (value != null) {
-                return Integer.parseInt(value.trim());
-            }
-            return null;
-        } catch (NumberFormatException e) {
+        String prioStr = getExpandedInAppUpdatePriorityString();
+        int priority = tryParseNumber(prioStr, Integer.MIN_VALUE).intValue();
+        if (priority == Integer.MIN_VALUE) {
             return null;
         }
+        return priority;
     }
 
     private boolean isConfigValid(PrintStream logger) throws IOException, InterruptedException {
@@ -269,14 +268,9 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
             }
         }
 
-        // Check if inAppUpdatePriority is a valid number if not null
-        if (inAppUpdatePriority != null) {
-            String expandedInAppUpdatePriorityStr = getExpandedInAppUpdatePriorityString();
-            try {
-                Integer.parseInt(expandedInAppUpdatePriorityStr);
-            } catch (NumberFormatException e) {
-                errors.add(String.format("'%s' is not a valid inAppUpdatePriority", expandedInAppUpdatePriorityStr));
-            }
+        // Check whether in-app priority could be parsed to a number
+        if (getExpandedInAppUpdatePriorityString() != null && getExpandedInAppUpdatePriority() == null) {
+            errors.add(String.format("'%s' is not a valid update priority", getExpandedInAppUpdatePriorityString()));
         }
 
         // Print accumulated errors

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder.java
@@ -271,10 +271,11 @@ public class ReleaseTrackAssignmentBuilder extends GooglePlayBuilder {
 
         // Check if inAppUpdatePriority is a valid number if not null
         if (inAppUpdatePriority != null) {
+            String expandedInAppUpdatePriorityStr = getExpandedInAppUpdatePriorityString();
             try {
-                Integer.parseInt(inAppUpdatePriority);
+                Integer.parseInt(expandedInAppUpdatePriorityStr);
             } catch (NumberFormatException e) {
-                errors.add(String.format("'%s' is not a valid inAppUpdatePriority", getExpandedInAppUpdatePriorityString()));
+                errors.add(String.format("'%s' is not a valid inAppUpdatePriority", expandedInAppUpdatePriorityStr));
             }
         }
 

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackAssignmentTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackAssignmentTask.java
@@ -84,7 +84,7 @@ class TrackAssignmentTask extends TrackPublisherTask<Boolean> {
         }
 
         if (inAppUpdatePriority != null) {
-            logger.println(String.format("Set inAppUpdatePriority to %d", inAppUpdatePriority));
+            logger.println(String.format("Setting in-app update priority to %d", inAppUpdatePriority));
         }
 
         // Attempt to locate any release notes already uploaded for these files, so we can assign them to the new track

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackAssignmentTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackAssignmentTask.java
@@ -25,8 +25,9 @@ class TrackAssignmentTask extends TrackPublisherTask<Boolean> {
     private final List<Long> versionCodes;
 
     TrackAssignmentTask(TaskListener listener, GoogleRobotCredentials credentials, String applicationId,
-                        Collection<Long> versionCodes, String trackName, double rolloutPercentage) {
-        super(listener, credentials, applicationId, trackName, rolloutPercentage);
+                        Collection<Long> versionCodes, String trackName, double rolloutPercentage,
+                        Integer inAppUpdatePriority) {
+        super(listener, credentials, applicationId, trackName, rolloutPercentage, inAppUpdatePriority);
         this.versionCodes = new ArrayList<>(versionCodes);
     }
 
@@ -82,6 +83,10 @@ class TrackAssignmentTask extends TrackPublisherTask<Boolean> {
             return false;
         }
 
+        if (inAppUpdatePriority != null) {
+            logger.println(String.format("Set inAppUpdatePriority to %d", inAppUpdatePriority));
+        }
+
         // Attempt to locate any release notes already uploaded for these files, so we can assign them to the new track
         final Long latestVersion = versionCodes.stream().max(Long::compareTo).orElse(0L);
         List<LocalizedText> releaseNotes = editService.tracks().list(applicationId, editId).execute().getTracks()
@@ -96,7 +101,7 @@ class TrackAssignmentTask extends TrackPublisherTask<Boolean> {
             .orElse(null);
 
         // Assign the version codes to the configured track
-        TrackRelease release = Util.buildRelease(versionCodes, rolloutFraction, releaseNotes);
+        TrackRelease release = Util.buildRelease(versionCodes, rolloutFraction, inAppUpdatePriority, releaseNotes);
         assignAppFilesToTrack(trackName, rolloutFraction, release);
 
         // Commit the changes

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackPublisherTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackPublisherTask.java
@@ -14,13 +14,15 @@ abstract class TrackPublisherTask<V> extends AbstractPublisherTask<V> {
     protected final String applicationId;
     protected String trackName;
     protected final double rolloutFraction;
+    protected final Integer inAppUpdatePriority;
 
     TrackPublisherTask(TaskListener listener, GoogleRobotCredentials credentials, String applicationId,
-                       String trackName, double rolloutPercentage) {
+                       String trackName, double rolloutPercentage, Integer inAppUpdatePriority) {
         super(listener, credentials);
         this.applicationId = applicationId;
         this.trackName = trackName;
         this.rolloutFraction = rolloutPercentage / 100d;
+        this.inAppUpdatePriority = inAppUpdatePriority;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/Util.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/Util.java
@@ -122,7 +122,7 @@ public class Util {
     }
 
     static TrackRelease buildRelease(
-        List<Long> versionCodes, double userFraction, @Nullable List<LocalizedText> releaseNotes
+        List<Long> versionCodes, double userFraction, Integer inAppUpdatePriority, @Nullable List<LocalizedText> releaseNotes
     ) {
         final String status;
         final Double fraction;
@@ -144,6 +144,7 @@ public class Util {
         TrackRelease release = new TrackRelease()
                 .setVersionCodes(versionCodes)
                 .setUserFraction(fraction)
+                .setInAppUpdatePriority(inAppUpdatePriority)
                 .setStatus(status);
 
         if (releaseNotes != null) release.setReleaseNotes(releaseNotes);

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
@@ -34,4 +34,8 @@
     <f:repeatableProperty field="recentChangeList" add="${%Add language...}" minimum="0" />
   </f:entry>
 
+  <f:entry title="${%InAppUpdatePriority %}" field="inAppUpdatePriority">
+      <f:textbox style="width:15em" />
+    </f:entry>
+
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
@@ -30,12 +30,13 @@
     <f:textbox style="width:15em" default="${descriptor.defaultRolloutPercentage}%" />
   </f:entry>
 
+  <f:entry title="${%In-app update priority}" field="inAppUpdatePriority"
+      description="${%Optional; defaults to 0 if not set}">
+    <f:textbox style="width:15em" />
+  </f:entry>
+
   <f:entry title="${%Recent changes}" field="recentChangeList">
     <f:repeatableProperty field="recentChangeList" add="${%Add language...}" minimum="0" />
   </f:entry>
-
-  <f:entry title="${%InAppUpdatePriority %}" field="inAppUpdatePriority">
-      <f:textbox style="width:15em" />
-    </f:entry>
 
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-inAppUpdatePriority.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-inAppUpdatePriority.html
@@ -1,8 +1,12 @@
 <div>
-  The inAppUpdatePriority to use it can be empty.
-
-  For more information on using the inAppUpdatePriority,
-  see the Google Play documentation of In-App update feature:<br/>
+  Specifies the priority of this app release for the in-app update feature
+  of the Google Play Core Library.
+  <p/>
+  If you don't use this feature, or don't need to set a priority, you can leave
+  this field blank; it will default to 0. Otherwise the value must be a whole
+  number between 0 (lowest priority) and 5 (highest priority).
+  <p/>
+  For more information on using in-app updates, see the documentation:<br/>
   <a href='https://developer.android.com/guide/playcore/in-app-updates'>
     https://developer.android.com/guide/playcore/in-app-updates
   </a>

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-inAppUpdatePriority.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-inAppUpdatePriority.html
@@ -1,0 +1,12 @@
+<div>
+  The inAppUpdatePriority to use it can be empty.
+
+  For more information on using the inAppUpdatePriority,
+  see the Google Play documentation of In-App update feature:<br/>
+  <a href='https://developer.android.com/guide/playcore/in-app-updates'>
+    https://developer.android.com/guide/playcore/in-app-updates
+  </a>
+  <hr/>
+  This field supports substituting environment variables in the form
+  <tt>${SOME_VARIABLE}</tt> or <tt>$SOME_VARIABLE</tt> at build time.
+</div>

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/config.jelly
@@ -38,7 +38,8 @@
     <f:textbox style="width:15em" default="${descriptor.defaultRolloutPercentage}%" />
   </f:entry>
 
-  <f:entry title="${%InAppUpdatePriority %}" field="inAppUpdatePriority">
+  <f:entry title="${%In-app update priority}" field="inAppUpdatePriority"
+      description="${%Optional; defaults to 0 if not set}">
     <f:textbox style="width:15em" />
   </f:entry>
 

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/config.jelly
@@ -38,4 +38,8 @@
     <f:textbox style="width:15em" default="${descriptor.defaultRolloutPercentage}%" />
   </f:entry>
 
+  <f:entry title="${%InAppUpdatePriority %}" field="inAppUpdatePriority">
+    <f:textbox style="width:15em" />
+  </f:entry>
+
 </j:jelly>

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/help-inAppUpdatePriority.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/help-inAppUpdatePriority.html
@@ -1,8 +1,12 @@
 <div>
-  The inAppUpdatePriority to use it can be empty.
-
-  For more information on using the inAppUpdatePriority,
-  see the Google Play documentation of In-App update feature:<br/>
+  Specifies the priority of this app release for the in-app update feature
+  of the Google Play Core Library.
+  <p/>
+  If you don't use this feature, or don't need to set a priority, you can leave
+  this field blank; it will default to 0. Otherwise the value must be a whole
+  number between 0 (lowest priority) and 5 (highest priority).
+  <p/>
+  For more information on using in-app updates, see the documentation:<br/>
   <a href='https://developer.android.com/guide/playcore/in-app-updates'>
     https://developer.android.com/guide/playcore/in-app-updates
   </a>

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/help-inAppUpdatePriority.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilder/help-inAppUpdatePriority.html
@@ -1,0 +1,12 @@
+<div>
+  The inAppUpdatePriority to use it can be empty.
+
+  For more information on using the inAppUpdatePriority,
+  see the Google Play documentation of In-App update feature:<br/>
+  <a href='https://developer.android.com/guide/playcore/in-app-updates'>
+    https://developer.android.com/guide/playcore/in-app-updates
+  </a>
+  <hr/>
+  This field supports substituting environment variables in the form
+  <tt>${SOME_VARIABLE}</tt> or <tt>$SOME_VARIABLE</tt> at build time.
+</div>

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
@@ -146,6 +146,40 @@ public class ApkPublisherTest {
     }
 
     @Test
+    public void uploadingWithoutInAppUpdatePrioritySucceeds() throws Exception{
+        // Given a step with a deprecated `rolloutPercent` value
+        String stepDefinition = "androidApkUpload googleCredentialsId: 'test-credentials',\n" +
+                "  trackName: 'production'";
+
+        uploadApkWithPipelineAndAssertSuccess(stepDefinition);
+    }
+
+    @Test
+    public void uploadingWithInAppUpdatePrioritySucceeds() throws Exception{
+        // Given a step with a deprecated `rolloutPercent` value
+        String stepDefinition = "androidApkUpload googleCredentialsId: 'test-credentials',\n" +
+                "  trackName: 'production',\n"+
+                "  inAppUpdatePriority: '1'";
+
+        uploadApkWithPipelineAndAssertSuccess(stepDefinition,
+                "Set inAppUpdatePriority to 1");
+    }
+
+    @Test
+    public void uploadingWithIncorrectInAppUpdatePriorityFails() throws Exception{
+        // Given a step with a deprecated `rolloutPercent` value
+        String stepDefinition = "androidApkUpload googleCredentialsId: 'test-credentials',\n" +
+                "  trackName: 'production',\n"+
+                "  inAppUpdatePriority: 'fake'";
+
+        // When a build occurs, it should roll out to that percentage
+        uploadApkWithPipelineAndAssertFailure(
+                stepDefinition,
+                "'fake' is not a valid inAppUpdatePriority"
+        );
+    }
+
+    @Test
     public void uploadingWithEmptyTrackNameFails() throws Exception {
         // Given a job where the track name is empty (e.g. saved without entering a value, or an empty parameter value)
         FreeStyleProject p = j.createFreeStyleProject();

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
@@ -162,7 +162,7 @@ public class ApkPublisherTest {
                 "  inAppUpdatePriority: '1'";
 
         uploadApkWithPipelineAndAssertSuccess(stepDefinition,
-                "Set inAppUpdatePriority to 1");
+                "Setting in-app update priority to 1");
     }
 
     @Test
@@ -175,7 +175,7 @@ public class ApkPublisherTest {
         // When a build occurs, it should roll out to that percentage
         uploadApkWithPipelineAndAssertFailure(
                 stepDefinition,
-                "'fake' is not a valid inAppUpdatePriority"
+                "'fake' is not a valid update priority"
         );
     }
 

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilderTest.java
@@ -319,6 +319,18 @@ public class ReleaseTrackAssignmentBuilderTest {
         moveApkTrackWithPipelineAndAssertFailure(stepDefinition, "Release track was not specified");
     }
 
+
+    @Test
+    public void movingApkTrackWithPipelineWithInvalidInAppUpdatePriorityFails() throws Exception {
+        // Given a Pipeline where the inAppUpdatePriority is not provided
+        String stepDefinition = "androidApkMove googleCredentialsId: 'test-credentials',\n" +
+                "inAppUpdatePriority: 'fake'";
+
+        // When a build occurs
+        // Then it should fail as inAppUpdatePriority is invalid
+        moveApkTrackWithPipelineAndAssertFailure(stepDefinition, "'fake' is not a valid inAppUpdatePriority");
+    }
+
     @Test
     public void moveApkTrackWithPipeline_succeeds() throws Exception {
         String stepDefinition =
@@ -330,6 +342,38 @@ public class ReleaseTrackAssignmentBuilderTest {
 
         moveApkTrackWithPipelineAndAssertSuccess(
             stepDefinition, "Setting rollout to target 100% of 'production' track users"
+        );
+    }
+
+    @Test
+    public void moveApkTrackWithPipeline_succeeds_without_inAppUpdatePriority() throws Exception {
+        String stepDefinition =
+            "  androidApkMove googleCredentialsId: 'test-credentials',\n" +
+            "    trackName: 'production',\n" +
+            "    fromVersionCode: true,\n" +
+            "    applicationId: 'org.jenkins.appId',\n" +
+            "    versionCodes: '42'";
+
+        moveApkTrackWithPipelineAndAssertSuccess(
+            stepDefinition,
+                "Setting rollout to target 100% of 'production' track users"
+        );
+    }
+
+    @Test
+    public void moveApkTrackWithPipeline_succeeds_with_inAppUpdatePriority() throws Exception {
+        String stepDefinition =
+            "  androidApkMove googleCredentialsId: 'test-credentials',\n" +
+            "    trackName: 'production',\n" +
+            "    fromVersionCode: true,\n" +
+            "    applicationId: 'org.jenkins.appId',\n" +
+            "    versionCodes: '42',\n" +
+            "    inAppUpdatePriority: '2'\n";
+
+        moveApkTrackWithPipelineAndAssertSuccess(
+            stepDefinition,
+                "Setting rollout to target 100% of 'production' track users",
+                "Set inAppUpdatePriority to 2"
         );
     }
 

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilderTest.java
@@ -328,7 +328,7 @@ public class ReleaseTrackAssignmentBuilderTest {
 
         // When a build occurs
         // Then it should fail as inAppUpdatePriority is invalid
-        moveApkTrackWithPipelineAndAssertFailure(stepDefinition, "'fake' is not a valid inAppUpdatePriority");
+        moveApkTrackWithPipelineAndAssertFailure(stepDefinition, "'fake' is not a valid update priority");
     }
 
     @Test
@@ -373,7 +373,7 @@ public class ReleaseTrackAssignmentBuilderTest {
         moveApkTrackWithPipelineAndAssertSuccess(
             stepDefinition,
                 "Setting rollout to target 100% of 'production' track users",
-                "Set inAppUpdatePriority to 2"
+                "Setting in-app update priority to 2"
         );
     }
 

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/UtilsTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/UtilsTest.java
@@ -33,7 +33,7 @@ public class UtilsTest {
     public void buildRelease_basicInputs() {
         List<Long> versionCodes = Arrays.asList(1L, 2L, 3L);
         double fraction = 0.05;
-        TrackRelease track = Util.buildRelease(versionCodes, fraction, null);
+        TrackRelease track = Util.buildRelease(versionCodes, fraction,  null, null);
 
         assertThat(track.getVersionCodes(), contains(1L, 2L, 3L));
         assertEquals(0.05, track.getUserFraction(), 0.001);
@@ -45,7 +45,7 @@ public class UtilsTest {
     public void buildRelease_withZeroFraction_releaseIsComplete() {
         List<Long> versionCodes = Arrays.asList(1L, 2L, 3L);
         double fraction = 0.0;
-        TrackRelease track = Util.buildRelease(versionCodes, fraction, null);
+        TrackRelease track = Util.buildRelease(versionCodes, fraction, null, null);
 
         assertNull(track.getUserFraction());
         assertEquals("draft", track.getStatus());
@@ -55,10 +55,22 @@ public class UtilsTest {
     public void buildRelease_withNonZeroFraction_releaseIsInProgress() {
         List<Long> versionCodes = Arrays.asList(1L, 2L, 3L);
         double fraction = 0.123;
-        TrackRelease track = Util.buildRelease(versionCodes, fraction, null);
+        TrackRelease track = Util.buildRelease(versionCodes, fraction, null, null);
 
         assertEquals(0.123, track.getUserFraction(), 0.0001);
         assertEquals("inProgress", track.getStatus());
+    }
+
+    @Test
+    public void buildRelease_withInAppUpdatePriority_trackRelease_contains_inAppUpdatePriority() {
+        List<Long> versionCodes = Arrays.asList(1L, 2L, 3L);
+        double fraction = 0.123;
+        Integer priority = 1;
+        TrackRelease track = Util.buildRelease(versionCodes, fraction, priority, null);
+
+        assertEquals(0.123, track.getUserFraction(), 0.0001);
+        assertEquals("inProgress", track.getStatus());
+        assertEquals(priority, track.getInAppUpdatePriority());
     }
 
     @Test


### PR DESCRIPTION
In this PR I add the support of inAppUpdatePriority feature that allow us to set the priority of the new version released. It seems that for now it's the only way to work with the In-App update feature otherwise the priority is always set to the default one 0.

Based on the documentation 
https://developer.android.com/guide/playcore/in-app-updates and  https://developers.google.com/android-publisher/api-ref/rest/v3/edits.tracks

I tried to integrate it inside the current version of the plugin and added the documentation for it. I have one concern about the TrackAssignmentTask I don't know what is the actual impact of the priority here. 

Even in this discussion it's not clear https://issuetracker.google.com/issues/133299031. 

I'm going to try my changes into a local version of staging and I will apply some change if needed.