### PR TITLE
Support uploading native debug symbol files.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Enables Jenkins to manage and upload Android app files (AAB or APK) to Google Pl
 - Uploading Android App Bundle (AAB) or APK files to Google Play
   - This includes apps which use Multiple APK support
   - ProGuard `mapping.txt` files can also be associated with each app file, for deobfuscating stacktraces
+  - Native debug symbol `lib.zip` files can also be associated with each app file, for deobfuscating native crash dumps
   - The update priority can also be set, if using [in-app updates][gp-docs-inappupdates]
 -  Uploading APK expansion (.obb) files
    - With the option to re-use expansion files from existing APKs, e.g. for patch releases
@@ -184,6 +185,7 @@ The `androidApkUpload` build step lets you upload Android App Bundle (AAB) or AP
 | rolloutPercentage                  | string  | `'1.5'`                | (none)                                                   | The rollout percentage to set on the track; use 0% to create a draft release                                           |
 | ~rolloutPercent~<br>(deprecated)   | number  | `1.5`                  | (none)                                                   | (deprecated, but still supported; prefer `rolloutPercentage` instead — it takes priority if both are defined)          |
 | deobfuscationFiles<br>Pattern      | string  | `'**/mapping.txt'`     | (none)                                                   | Comma-separated glob patterns or filenames pointing to ProGuard mapping files to associate with the uploaded app files |
+| nativeDebugSymbolFiles<br>Pattern      | string  | `'**/lib.zip'`     | (none)                                                   | Comma-separated glob patterns or filenames pointing to native debug symbol files to associate with the uploaded app files |
 | expansionFilesPattern              | string  | `'**/*.obb'`           | (none)                                                   | Comma-separated glob patterns or filenames pointing to expansion files to associate with the uploaded APK files        |
 | usePreviousExpansion<br>FilesIfMissing | boolean | `false`            | `true`                                                   | Whether to re-use the existing expansion files that have already been uploaded to Google Play for this app, if any expansion files are missing |
 | recentChangeList                   | list    | (see below)            | (empty)                                                  | List of recent change texts to associate with the upload app files                                                     |
@@ -205,6 +207,7 @@ androidApkUpload googleCredentialsId: 'My Google Play account',
                  trackName: 'dogfood',
                  rolloutPercentage: '25',
                  deobfuscationFilesPattern: '**/build/outputs/**/mapping.txt',
+                 nativeDebugSymbolFilesPattern: '**/build/outputs/**/lib.zip',
                  inAppUpdatePriority: '2',
                  recentChangeList: [
                    [language: 'en-GB', text: "Please test the changes from Jenkins build ${env.BUILD_NUMBER}."],

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
@@ -33,6 +33,7 @@ import static hudson.Functions.humanReadableByteSize;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.ApkPublisher.ExpansionFileSet;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.ApkPublisher.RecentChanges;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.DEOBFUSCATION_FILE_TYPE_PROGUARD;
+import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.DEOBFUSCATION_FILE_TYPE_NATIVE_CODE;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.OBB_FILE_TYPE_MAIN;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.OBB_FILE_TYPE_PATCH;
 
@@ -161,6 +162,24 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
                             new FileContent("application/octet-stream", new File(mappingFile.getRemote()));
                     editService.deobfuscationfiles().upload(applicationId, editId, Math.toIntExact(uploadedVersionCode),
                             DEOBFUSCATION_FILE_TYPE_PROGUARD, mapping).execute();
+                }
+            }
+
+            // Upload the native debug symbol file for this file, if there is one
+            final FilePath nativeDebugSymbolFile = appFile.getNativeDebugSymbolFile();
+            if (nativeDebugSymbolFile != null) {
+                final String relativeFileName = getRelativeFileName(nativeDebugSymbolFile);
+
+                // Google Play API doesn't accept empty native debug symbol files
+                logger.println(String.format(" Native debug symbol file size: %s", nativeDebugSymbolFile.length()));
+                if (nativeDebugSymbolFile.length() == 0) {
+                    logger.println(String.format(" Ignoring empty native debug symbol file: %s", relativeFileName));
+                } else {
+                    logger.println(String.format(" Uploading associated native debug symbol file: %s", relativeFileName));
+                    FileContent nativeDebugSymbol =
+                            new FileContent("application/octet-stream", new File(nativeDebugSymbolFile.getRemote()));
+                    editService.deobfuscationfiles().upload(applicationId, editId, Math.toIntExact(uploadedVersionCode),
+                            DEOBFUSCATION_FILE_TYPE_NATIVE_CODE, nativeDebugSymbol).execute();
                 }
             }
             logger.println("");

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/Constants.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/Constants.java
@@ -8,6 +8,9 @@ public class Constants {
     /** Deobfuscation file type: proguard */
     public static final String DEOBFUSCATION_FILE_TYPE_PROGUARD = "proguard";
 
+    /** Deobfuscation file type: native debugging symbols */
+    public static final String DEOBFUSCATION_FILE_TYPE_NATIVE_CODE = "nativeCode";
+
     /** File name pattern which expansion files must match. */
     static final Pattern OBB_FILE_REGEX =
             Pattern.compile("^(main|patch)\\.([0-9]+)\\.([._a-z0-9]+)\\.obb$", Pattern.CASE_INSENSITIVE);

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/UploadFile.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/UploadFile.java
@@ -18,6 +18,7 @@ public class UploadFile implements Serializable {
     private AppFileMetadata metadata;
     private String sha1Hash;
     private FilePath mappingFile;
+    private FilePath nativeDebugSymbolFile;
 
     public UploadFile(FilePath filePath) throws IOException, InterruptedException {
         this.filePath = filePath;
@@ -67,6 +68,14 @@ public class UploadFile implements Serializable {
 
     public void setMappingFile(FilePath file) {
         this.mappingFile = file;
+    }
+
+    public FilePath getNativeDebugSymbolFile() {
+        return nativeDebugSymbolFile;
+    }
+
+    public void setNativeDebugSymbolFile(FilePath file) {
+        this.nativeDebugSymbolFile = file;
     }
 
     private static final class GetHashTask extends MasterToSlaveFileCallable<String> {

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/config.jelly
@@ -15,6 +15,11 @@
     <f:textbox />
   </f:entry>
 
+  <f:entry title="${%Native debug symbol files}" field="nativeDebugSymbolFilesPattern"
+      description="${%Optional, comma-separated list of filenames or patterns}">
+    <f:textbox />
+  </f:entry>
+
   <f:entry title="${%Expansion files}" field="expansionFilesPattern">
     <f:textbox />
     <f:checkbox title="${%Re-use expansion files from existing APKs where necessary}"

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
@@ -111,6 +111,7 @@ public class ApkPublisherTest {
         publisher.setGoogleCredentialsId("credential-b");
         publisher.setFilesPattern("**/builds/*.apk, *.aab");
         publisher.setDeobfuscationFilesPattern("**/proguard/*.txt");
+        publisher.setNativeDebugSymbolFilesPattern("**/native/*.zip");
         publisher.setExpansionFilesPattern("${EXP_FILES}");
         publisher.setUsePreviousExpansionFilesIfMissing(true);
         publisher.setTrackName("alpha");


### PR DESCRIPTION
This PR adds support to upload native debug symbol files (zip file of unstripped .so files) along with the APKs and mapping files.

Tested in-house and it can uploads multiple apks with corresponding mapping files and native debug symbol zip files successfully.

> Authenticating to Google Play API...
> - Credential:     android-subscription
> - Application ID: com.cloudmosa.puffin
> 
> Uploading 4 file(s) with application ID: com.cloudmosa.puffin
> 
>       APK file: arm64-v8a/puffin.apk
>      File size: 23.94 MB
>     SHA-1 hash: ebf482f2ad7c4e3a8561b87b54d4db49898156e7
>    versionCode: 10050241
>  minSdkVersion: 19
> 
>  Mapping file size: 8842500
>  Uploading associated ProGuard mapping file: arm64-v8a/mapping.txt
> 
>  Native debug symbol file size: 76550818
>  Uploading associated native debug symbol file: arm64-v8a/lib.zip
> 
>       APK file: armeabi-v7a/puffin.apk
>      File size: 22.44 MB
>     SHA-1 hash: fbe87d64e77a6e7e9b1ad2ffe4412d6063464422
>    versionCode: 50241
>  minSdkVersion: 19
> 
>  Mapping file size: 8842500
>  Uploading associated ProGuard mapping file: armeabi-v7a/mapping.txt
> 
>  Native debug symbol file size: 76009135
>  Uploading associated native debug symbol file: armeabi-v7a/lib.zip
> 
>       APK file: x86/puffin.apk
>      File size: 25.03 MB
>     SHA-1 hash: 32aa61d1abe0f1ca8fa55cb4cdbe90d92a2b2ab9
>    versionCode: 20050241
>  minSdkVersion: 19
> 
>  Mapping file size: 8842500
>  Uploading associated ProGuard mapping file: x86/mapping.txt
> 
>  Native debug symbol file size: 78502744
>  Uploading associated native debug symbol file: x86/lib.zip
> 
>       APK file: x86_64/puffin.apk
>      File size: 24.86 MB
>     SHA-1 hash: d53bcb75936911209a30d47b4e5a4af2fd657138
>    versionCode: 30050241
>  minSdkVersion: 19
> 
>  Mapping file size: 8842500
>  Uploading associated ProGuard mapping file: x86_64/mapping.txt
> 
>  Native debug symbol file size: 78375742
>  Uploading associated native debug symbol file: x86_64/lib.zip
> 
> Setting rollout to target 100% of 'internal' track users
> 
> The 'internal' release track will now contain the version code(s): 10050241, 50241, 20050241, 30050241
> 
> Applying changes to Google Play...
> 
> Changes were successfully applied to Google Play
> Finished: SUCCESS
> 

Ran `mvn test` with no failures.

> [INFO] -------------------------------------------------------
> [INFO]  T E S T S
> [INFO] -------------------------------------------------------
> [INFO] Running InjectedTest
> [INFO] Tests run: 7, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 10.629 s - in InjectedTest
> [INFO] Running org.jenkinsci.plugins.googleplayandroidpublisher.ApkPublisherTest
> 
> [WARNING] Tests run: 34, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 79.316 s - in org.jenkinsci.plugins.googleplayandroidpublisher.ApkPublisherTest
> [INFO] Running org.jenkinsci.plugins.googleplayandroidpublisher.ReleaseTrackAssignmentBuilderTest
> [WARNING] Tests run: 25, Failures: 0, Errors: 0, Skipped: 1, Time elapsed: 58.581 s - in org.jenkinsci.plugins.googleplayandroidpublisher.ReleaseTrackAssignmentBuilderTest
> [INFO] Running org.jenkinsci.plugins.googleplayandroidpublisher.UtilsTest
> [INFO] Tests run: 10, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.003 s - in org.jenkinsci.plugins.googleplayandroidpublisher.UtilsTest
> [INFO] 
> [INFO] Results:
> [INFO] 
> [WARNING] Tests run: 76, Failures: 0, Errors: 0, Skipped: 2
> 