### PR TITLE
Tidying up before release

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ The `androidApkUpload` build step lets you upload Android App Bundle (AAB) or AP
 | googlePlayCredentialsId            | string  | `'Google Play creds'`  | (none)                                                   | Name of the Google Service Account credential created in Jenkins                                                       |
 | filesPattern                       | string  | `'release/my-app.aab'` | `'**/build/outputs/**/*.aab, **/build/outputs/**/*.apk'` | Comma-separated glob patterns or filenames pointing to the app files to upload, relative to the root of the workspace  |
 | trackName                          | string  | `'internal'`           | (none)                                                   | Google Play track to which the app files should be published                                                           |
-| releaseName                        | string  | `'1.2.3'   `           | (none)                                                   | Name used to identify this release in the Play Console UI. Generated from the version_name in the APKs if not set.     |
+| releaseName                        | string  | `'1.2.3'`              | (none)                                                   | Name used to identify this release in the Google Play Console. If not set, Google Play will use the app version name   |
 | rolloutPercentage                  | string  | `'1.5'`                | (none)                                                   | The rollout percentage to set on the track; use 0% to create a draft release                                           |
 | ~rolloutPercent~<br>(deprecated)   | number  | `1.5`                  | (none)                                                   | (deprecated, but still supported; prefer `rolloutPercentage` instead — it takes priority if both are defined)          |
 | deobfuscationFiles<br>Pattern      | string  | `'**/mapping.txt'`     | (none)                                                   | Comma-separated glob patterns or filenames pointing to ProGuard mapping files to associate with the uploaded app files |
@@ -206,6 +206,7 @@ androidApkUpload googleCredentialsId: 'My Google Play account',
                  filesPattern: '**/build/outputs/**/*.aab',
                  trackName: 'dogfood',
                  rolloutPercentage: '25',
+                 releaseName: 'Test build ({versionCode})',
                  deobfuscationFilesPattern: '**/build/outputs/**/mapping.txt',
                  nativeDebugSymbolFilesPattern: '**/build/outputs/**/native-debug-symbols.zip',
                  inAppUpdatePriority: '2',
@@ -230,14 +231,14 @@ The `androidApkMove` build step lets you move existing Android app versions (whe
 |-------------------------|---------|------------------------|----------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------|
 | googlePlayCredentialsId | string  | `'Google Play creds'`  | (none)                                                   | Name of the Google Service Account credential created in Jenkins                                                                |
 | trackName               | string  | `'internal'`           | (none)                                                   | Google Play release track to update with the given app versions                                                                 |
-| releaseName             | string  | `'1.2.3'   `           | (none)                                                   | Name used to identify this release in the Play Console UI. Generated from the version_name in the APKs if not set.              |
+| releaseName             | string  | `'1.2.3'`              | (none)                                                   | Name used to identify this release in the Google Play Console. If not set, Google Play will use the app version name            |
 | rolloutPercentage       | string  | `'1.5'`                | (none)                                                   | The rollout percentage to set on the given release track; use 0% to create a draft release                                      |
 | ~rolloutPercent~<br>(deprecated) | number  | `1.5`         | (none)                                                   | (deprecated, but still supported; prefer `rolloutPercentage` instead — it takes priority if both are defined)                   |
 | fromVersionCode         | boolean | `true`                 | `false`                                                  | If true, the `applicationId` and `versionCodes` parameters will be used. Otherwise the `filesPattern` parameter will be used    |
 | applicationId           | string  | `'com.example.app'`    | (none)                                                   | The application ID of the app to update                                                                                         |
 | versionCodes            | string  | `'1281, 1282, 1283'`   | (none)                                                   | Comma-separated list of version codes to set on the given release track                                                         |
 | filesPattern            | string  | `'release/my-app.aab'` | `'**/build/outputs/**/*.aab, **/build/outputs/**/*.apk'` | Comma-separated glob patterns or filenames pointing to the files from which the application ID and version codes should be read |
-| inAppUpdatePriority     | string  | `'1'`                  | `'0'`                                                    | Priority of this release, used by the Google Play Core in-app update feature                                           |
+| inAppUpdatePriority     | string  | `'1'`                  | `'0'`                                                    | Priority of this release, used by the Google Play Core in-app update feature                                                    |
 
 The `googlePlayCredentialsId`, `trackName`, and `rolloutPercentage` parameters are mandatory, plus either an application ID and version code(s), or AAB or APK file(s) to read this information from.
 
@@ -267,6 +268,19 @@ androidApkMove googleCredentialsId: 'My Google Play account',
                applicationId: 'com.example.app',
                versionCodes: '1281, 1282, 1283'
 ```
+
+#### Setting the release name
+You can optionally set the release name, used to identify a particular release in the Google Play Console. This isn't visible to end users.
+
+If this option is not used, Google Play will set the release name to the versionName of the app file being uploaded, for
+example: "1.2.34".
+
+When uploading app files and setting a release name value, any instances of `{versionCode}` or `{versionName}` in the value
+will be replaced at build time by the respective value from the app file being uploaded. If multiple app files are being
+uploaded, the values from the file with lowest versionCode will be used.
+
+For example, entering `releaseName: "Release v{versionName}_${env.GIT_COMMIT}"` in a Pipeline could yield a release name
+on Google Play something like "Release v1.2.34_b2c3d3e4".
 
 #### Backwards-compatibility
 ##### Version 3.0

--- a/README.md
+++ b/README.md
@@ -9,11 +9,10 @@ Enables Jenkins to manage and upload Android app files (AAB or APK) to Google Pl
 ## Features
 - Uploading Android App Bundle (AAB) or APK files to Google Play
   - This includes apps which use Multiple APK support
-  - ProGuard `mapping.txt` files can also be associated with each app file, for deobfuscating stacktraces
-  - Native debug symbol `lib.zip` files can also be associated with each app file, for deobfuscating native crash dumps
-  - The update priority can also be set, if using [in-app updates][gp-docs-inappupdates]
--  Uploading APK expansion (.obb) files
-   - With the option to re-use expansion files from existing APKs, e.g. for patch releases
+  - ProGuard `mapping.txt` and native debug symbols can also be associated with each app file, for deobfuscating crash dumps
+  - The update priority can be set, if using [in-app updates][gp-docs-inappupdates]
+  - APK expansion (.obb) files can also be uploaded
+    - With the option to re-use expansion files from existing APKs, e.g. for patch releases
 - Assigning apps to internal, alpha, beta, production, or custom release tracks
   - This includes a build step for moving existing versions to a different track, or updating the rollout percentage   
     e.g. You can upload an alpha in one job, then later have another job promote it to beta
@@ -21,7 +20,7 @@ Enables Jenkins to manage and upload Android app files (AAB or APK) to Google Pl
 - Uploading files without yet rolling out, creating a draft release
 - Assigning release notes to uploaded files, for various languages
 - Changing the Jenkins build result to failed if the configuration is bad, or uploading or moving app files fails for some reason
--  Every configuration field supports variable and [token][plugin-token-macro] expansion, allowing release notes to be dynamically generated, for example
+- Every configuration field supports variable and [token][plugin-token-macro] expansion, allowing release notes to be dynamically generated, for example
 - Integration with the [Google OAuth Credentials Plugin][plugin-google-oauth], so that Google Play credentials can be entered once globally, stored securely, and shared between jobs
   - Multiple Google Play accounts are also supported via this mechanism
 
@@ -186,7 +185,7 @@ The `androidApkUpload` build step lets you upload Android App Bundle (AAB) or AP
 | rolloutPercentage                  | string  | `'1.5'`                | (none)                                                   | The rollout percentage to set on the track; use 0% to create a draft release                                           |
 | ~rolloutPercent~<br>(deprecated)   | number  | `1.5`                  | (none)                                                   | (deprecated, but still supported; prefer `rolloutPercentage` instead — it takes priority if both are defined)          |
 | deobfuscationFiles<br>Pattern      | string  | `'**/mapping.txt'`     | (none)                                                   | Comma-separated glob patterns or filenames pointing to ProGuard mapping files to associate with the uploaded app files |
-| nativeDebugSymbolFiles<br>Pattern      | string  | `'**/lib.zip'`     | (none)                                                   | Comma-separated glob patterns or filenames pointing to native debug symbol files to associate with the uploaded app files |
+| nativeDebugSymbolFiles<br>Pattern  | string  | `'**/symbols.zip'`     | (none)                                                   | Comma-separated glob patterns or filenames pointing to native debug symbol files to associate with the uploaded app files |
 | expansionFilesPattern              | string  | `'**/*.obb'`           | (none)                                                   | Comma-separated glob patterns or filenames pointing to expansion files to associate with the uploaded APK files        |
 | usePreviousExpansion<br>FilesIfMissing | boolean | `false`            | `true`                                                   | Whether to re-use the existing expansion files that have already been uploaded to Google Play for this app, if any expansion files are missing |
 | recentChangeList                   | list    | (see below)            | (empty)                                                  | List of recent change texts to associate with the upload app files                                                     |
@@ -208,7 +207,7 @@ androidApkUpload googleCredentialsId: 'My Google Play account',
                  trackName: 'dogfood',
                  rolloutPercentage: '25',
                  deobfuscationFilesPattern: '**/build/outputs/**/mapping.txt',
-                 nativeDebugSymbolFilesPattern: '**/build/outputs/**/lib.zip',
+                 nativeDebugSymbolFilesPattern: '**/build/outputs/**/native-debug-symbols.zip',
                  inAppUpdatePriority: '2',
                  recentChangeList: [
                    [language: 'en-GB', text: "Please test the changes from Jenkins build ${env.BUILD_NUMBER}."],

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/CredentialsHandler.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/CredentialsHandler.java
@@ -12,7 +12,6 @@ import hudson.model.Item;
 import hudson.model.Queue;
 import hudson.model.queue.Tasks;
 import hudson.security.ACL;
-import jenkins.model.Jenkins;
 import org.acegisecurity.Authentication;
 import org.apache.commons.lang.exception.ExceptionUtils;
 
@@ -72,8 +71,8 @@ public class CredentialsHandler {
         } catch (GeneralSecurityException e) {
             if (ExceptionUtils.getRootCause(e) instanceof IOException) {
                 throw new EphemeralCredentialsException("Failed to validate Google Service Account credential " +
-                        "against the Google API servers. Check internet connectivity on the Jenkins server and try " +
-                        "again.", e);
+                        "against the Google API servers. Check internet connectivity on the Jenkins controller and " +
+                        "try again.", e);
             }
             throw new UploadException(e);
         }

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/CheckedFunction.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/CheckedFunction.java
@@ -1,8 +1,0 @@
-package org.jenkinsci.plugins.googleplayandroidpublisher.internal;
-
-import java.io.IOException;
-
-@FunctionalInterface
-public interface CheckedFunction<T, R> {
-    R apply(T t) throws IOException;
-}

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-deobfuscationFilesPattern.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-deobfuscationFilesPattern.html
@@ -3,6 +3,12 @@
   files that should be uploaded to Google Play, so that it can automatically
   deobfuscate stacktraces from crash reports.
   <p/>
+  Note that if you build an Android App Bundle (AAB file) with ProGuard enabled,
+  the mapping file should already be embedded in the app bundle (typically as
+  <tt>BUNDLE-METADATA/com.android.tools.build.obfuscation/proguard.map</tt>.<br/>
+  In such cases, you shouldn't use this option since Google Play will reject any
+  attempt to upload a mapping file when the app bundle has one embedded.
+  <p/>
   You can use wildcards like "<tt>**/build/**/mapping.txt</tt>".<br/>
   See <a href='https://ant.apache.org/manual/Types/fileset.html'>
   the 'includes' attribute of Ant's FileSet</a> for the exact format.<br/>
@@ -11,14 +17,14 @@
   The base directory is <a href='ws/'>the build's workspace</a>.
   You can only upload mapping files that are located in your workspace.
   <p/>
-  If there are multiple files being uploaded, and only one
-  <tt>mapping.txt</tt> file is found, then this file will be associated
-  with each of the files being uploaded. If there are multiple
-  <tt>mapping.txt</tt> files, this plugin will make a basic attempt to
-  associate each mapping file with the corresponding AAB/APK file.<br/>
-  Otherwise, if the number of mapping files found is not equal to the
-  number of APKs being uploaded, the build will fail, as this situation
-  is not supported.
+  If there are multiple AAB/APK files being uploaded, and only one mapping file
+  is found in the workspace, then that mapping file will be associated with
+  each of the app files being uploaded. If there are multiple mapping files
+  found, a basic attempt will be made to automatically associate each mapping
+  file with its corresponding app file.<br/>
+  Otherwise, if the number of mapping files found is <em>not</em> equal to the
+  number of app files being uploaded, the build will fail, as this situation is
+  not supported.
   <p/>
   For more information on deobfuscating crash stacktraces, see the
   Google Play documentation:<br/>

--- a/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-nativeDebugSymbolFilesPattern.html
+++ b/src/main/resources/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisher/help-nativeDebugSymbolFilesPattern.html
@@ -1,0 +1,39 @@
+<div>
+  Specifies filenames or patterns matching one or more zip files containing
+  native library symbols that should be uploaded to Google Play, so that it
+  can automatically deobfuscate native crash dumps.
+  <p/>
+  Note that if you build an Android App Bundle (AAB file) with native libraries,
+  using Android Gradle Plugin version 4.1 or newer, you can choose to
+  <a href='https://developer.android.com/studio/build/shrink-code#native-crash-support'>
+  automatically embed</a> the native symbols into the app bundle file.<br/>
+  Therefore you don't need to use this option to upload the symbols separately.
+  But if you do, the contents of this symbols file will supersede those embedded
+  in the bundle.
+  <p/>
+  You can use wildcards like "<tt>**/build/**/native-debug-symbols.zip</tt>".<br/>
+  See <a href='https://ant.apache.org/manual/Types/fileset.html'>
+  the 'includes' attribute of Ant's FileSet</a> for the exact format.<br/>
+  Note that multiple entries must be comma-separated.
+  <p/>
+  The base directory is <a href='ws/'>the build's workspace</a>.
+  You can only upload symbols files that are located in your workspace.
+  <p/>
+  If there are multiple AAB/APK files being uploaded, and only one symbols file
+  is found in the workspace, then that symbols file will be associated with
+  each of the app files being uploaded. If there are multiple symbols files
+  found, a basic attempt will be made to automatically associate each symbols
+  file with its corresponding app file.<br/>
+  Otherwise, if the number of symbols files found is <em>not</em> equal to the
+  number of app files being uploaded, the build will fail, as this situation is
+  not supported.
+  <p/>
+  For more information on deobfuscating crash stacktraces, see the
+  Google Play documentation:<br/>
+  <a href='https://support.google.com/googleplay/android-developer/answer/6295281'>
+    https://support.google.com/googleplay/android-developer/answer/6295281
+  </a>
+  <hr/>
+  This field supports substituting environment variables in the form
+  <tt>${SOME_VARIABLE}</tt> or <tt>$SOME_VARIABLE</tt> at build time.
+</div>


### PR DESCRIPTION
- Some follow-ups from #38:
  - Inline documentation
  - Refactoring duplicate code
- Tidied up logging a wee bit
- Added more documentation on customising release names