### PR TITLE
[JENKINS-65475] Upgrade bundle lib dependency to fix parser crash

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
     <dependency>
       <groupId>com.github.orrc</groupId>
       <artifactId>android-bundle-basics-lib</artifactId>
-      <version>v4</version>
+      <version>v5</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Update to [v5](https://github.com/orrc/android-bundle-basics-lib/tree/v5) of the bundle parser to fix a crash with certain .aab files, reported in [JENKINS-65475](https://issues.jenkins.io/browse/JENKINS-65475).