### PR TITLE
[JENKINS-65815] Handle changesNotSentForReview flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Enables Jenkins to manage and upload Android app files (AAB or APK) to Google Pl
 
 ## Requirements
 ### Jenkins
-Jenkins [version 2.164.3][lts-changelog] or newer is required.
+Jenkins [version 2.222.4][lts-changelog] or newer is required.
 
 ### Google Play publisher account
 For the initial setup only, you must have access to the Google account which owns the [Google Play publisher account][gp-docs-distribute].
@@ -408,7 +408,7 @@ See [CHANGELOG.md][changelog].
 [issues-existing]:https://issues.jenkins-ci.org/issues/?jql=project%20%3D%20JENKINS%20AND%20component%20%3D%20google-play-android-publisher-plugin%20AND%20status%20NOT%20IN(Closed%2C%20Resolved)%20ORDER%20BY%20updated%20DESC
 [issues-report]:https://jenkins.io/redirect/report-an-issue
 [jenkins-behind-proxy]:https://wiki.jenkins.io/display/JENKINS/JenkinsBehindProxy#JenkinsBehindProxy-HowJenkinshandlesProxyServers
-[lts-changelog]:https://jenkins.io/changelog-stable#v2.164.3
+[lts-changelog]:https://jenkins.io/changelog-stable#v2.222.4
 [plugin-google-oauth]:https://plugins.jenkins.io/google-oauth-plugin
 [plugin-jcasc]:https://plugins.jenkins.io/configuration-as-code
 [plugin-token-macro]:https://plugins.jenkins.io/token-macro

--- a/README.md
+++ b/README.md
@@ -320,8 +320,6 @@ In these cases you can try running your build again, or wait a few hours before 
 
 Please also consider [contacting Google Play Developer Support][gp-support-form] to help make them aware that people use the Google Play API, and that it should preferably work in a reliable manner.
 
-This plugin already recognises some temporary Google Play API server problems and works around them; more workarounds may be added in future, e.g. automatically retrying when a generic server error is encountered.
-
 ### Unable to retrieve an access token with the provided credentials
 If you see this error message, look further down the error log to see what is causing it. Below are a couple of common causes:
 

--- a/pom.xml
+++ b/pom.xml
@@ -9,9 +9,9 @@
   </parent>
 
   <properties>
-    <jenkins.version>2.164.3</jenkins.version>
-    <jenkins.bom.artifactId>2.164.x</jenkins.bom.artifactId>
-    <jenkins.bom.version>9</jenkins.bom.version>
+    <jenkins.version>2.222.4</jenkins.version>
+    <jenkins.bom.artifactId>2.222.x</jenkins.bom.artifactId>
+    <jenkins.bom.version>29</jenkins.bom.version>
     <java.level>8</java.level>
   </properties>
 
@@ -49,7 +49,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.11.0</version>
+      <version>2.12.3</version>
     </dependency>
 
     <!-- Official bindings for the Android Publisher API -->
@@ -101,6 +101,11 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.10</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>3.12.0</version>
+    </dependency>
 
     <!-- Testing -->
     <dependency>
@@ -122,7 +127,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>cloudbees-folder</artifactId>
-      <version>6.12</version>
+      <version>6.15</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -44,7 +44,7 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.10-2.0</version>
+      <version>4.5.13-1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
@@ -56,7 +56,7 @@
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-androidpublisher</artifactId>
-      <version>v3-rev142-1.25.0</version>
+      <version>v3-rev20210728-1.32.1</version>
     </dependency>
 
     <!-- To parse the APK file format -->
@@ -94,17 +94,19 @@
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.25.0</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.10</version>
+      <version>1.39.2</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
       <version>3.12.0</version>
+    </dependency>
+
+    <!-- Upgrade Guava, since google-http-client requires at least v15, rather than the v11 bundled with Jenkins -->
+    <dependency> <!-- see maskClasses config -->
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>30.1.1-jre</version>
     </dependency>
 
     <!-- Testing -->
@@ -208,6 +210,19 @@
       <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.jenkins-ci.tools</groupId>
+        <artifactId>maven-hpi-plugin</artifactId>
+        <configuration>
+          <!-- Workaround from JENKINS-36779, since we need a custom version of Guava -->
+          <maskClasses>com.google.common.</maskClasses>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
   <scm>
     <connection>scm:git:git://github.com/jenkinsci/google-play-android-publisher-plugin.git</connection>

--- a/pom.xml
+++ b/pom.xml
@@ -44,19 +44,29 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>apache-httpcomponents-client-4-api</artifactId>
-      <version>4.5.13-1.0</version>
     </dependency>
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>jackson2-api</artifactId>
-      <version>2.12.3</version>
     </dependency>
 
     <!-- Official bindings for the Android Publisher API -->
     <dependency>
       <groupId>com.google.apis</groupId>
       <artifactId>google-api-services-androidpublisher</artifactId>
+      <!-- Note that the last part of the version string corresponds to the compatible google-api-client version -->
       <version>v3-rev20210728-1.32.1</version>
+      <!-- We can avoid bundling these as they're provided by google-oauth-plugin -->
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.api-client</groupId>
+          <artifactId>google-api-client</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.http-client</groupId>
+          <artifactId>google-http-client</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- To parse the APK file format -->
@@ -76,7 +86,8 @@
     <dependency>
       <groupId>org.jenkins-ci.plugins</groupId>
       <artifactId>google-oauth-plugin</artifactId>
-      <version>1.0.0</version>
+      <!-- Awaiting https://github.com/jenkinsci/google-oauth-plugin/pull/129 -->
+      <version>1.0.7-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -90,23 +101,32 @@
       <artifactId>structs</artifactId>
     </dependency>
 
-    <!-- Pinning these versions as various other dependencies rely on them -->
+    <!--
+      Use a newer version of Guava, since google-http-client needs at least v14, rather than v11 bundled with Jenkins.
+      However, this usage should be masked from other consumers via the maven-hpi-plugin configuration below.
+      The exact version being used is defined by the com.google.cloud:libraries-bom
+    -->
     <dependency>
-      <groupId>com.google.http-client</groupId>
-      <artifactId>google-http-client</artifactId>
-      <version>1.39.2</version>
-    </dependency>
-    <dependency>
-      <groupId>com.google.protobuf</groupId>
-      <artifactId>protobuf-java</artifactId>
-      <version>3.12.0</version>
-    </dependency>
-
-    <!-- Upgrade Guava, since google-http-client requires at least v15, rather than the v11 bundled with Jenkins -->
-    <dependency> <!-- see maskClasses config -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>30.1.1-jre</version>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.errorprone</groupId>
+          <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.code.findbugs</groupId>
+          <artifactId>jsr305</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.checkerframework</groupId>
+          <artifactId>checker-compat-qual</artifactId>
+        </exclusion>
+     </exclusions>
     </dependency>
 
     <!-- Testing -->
@@ -182,6 +202,14 @@
         <version>${jenkins.bom.version}</version>
         <scope>import</scope>
         <type>pom</type>
+      </dependency>
+      <!-- Ensures Google lib version compatibility: https://googleapis.github.io/google-http-java-client/setup.html -->
+      <dependency>
+        <groupId>com.google.cloud</groupId>
+        <artifactId>libraries-bom</artifactId>
+        <version>20.9.0</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/AbstractPublisherTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/AbstractPublisherTask.java
@@ -1,5 +1,7 @@
 package org.jenkinsci.plugins.googleplayandroidpublisher;
 
+import com.google.api.client.googleapis.json.GoogleJsonError;
+import com.google.api.client.googleapis.json.GoogleJsonResponseException;
 import com.google.api.services.androidpublisher.AndroidPublisher;
 import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import hudson.model.TaskListener;
@@ -15,13 +17,15 @@ public abstract class AbstractPublisherTask<V> extends MasterToSlaveCallable<V, 
     private final GoogleRobotCredentials credentials;
     private final String pluginVersion;
     protected AndroidPublisher.Edits editService;
+    protected final String applicationId;
     protected String editId;
     protected PrintStream logger;
 
-    AbstractPublisherTask(TaskListener listener, GoogleRobotCredentials credentials) {
+    AbstractPublisherTask(TaskListener listener, GoogleRobotCredentials credentials, String applicationId) {
         this.listener = listener;
         this.credentials = credentials;
         this.pluginVersion = Util.getPluginVersion();
+        this.applicationId = applicationId;
     }
 
     public final V call() throws UploadException {
@@ -53,6 +57,36 @@ public abstract class AbstractPublisherTask<V> extends MasterToSlaveCallable<V, 
     /** Creates a new edit, assigning the {@link #editId}. Any previous edit ID will be lost. */
     protected final void createEdit(String applicationId) throws IOException {
         editId = editService.insert(applicationId, null).execute().getId();
+    }
+
+    protected void commit() throws IOException {
+        logger.println("Applying changes to Google Play...");
+        boolean cannotBeSentForReview = false;
+        try {
+            // Try committing and sending the changes for review
+            editService.commit(applicationId, editId).setChangesNotSentForReview(false).execute();
+        } catch (GoogleJsonResponseException e) {
+            // Check whether the commit was rejected because it can't be automatically submitted for review
+            GoogleJsonError details = e.getDetails();
+            if (details != null) {
+                String msg = details.getMessage();
+                cannotBeSentForReview = msg != null && msg.contains("changesNotSentForReview");
+            }
+
+            if (cannotBeSentForReview) {
+                // If so, we can retry without sending the changes for review
+                editService.commit(applicationId, editId).setChangesNotSentForReview(true).execute();
+            } else {
+                // The commit failed for another reason, so just rethrow
+                throw e;
+            }
+        }
+
+        // If committing didn't throw an exception, everything worked fine
+        logger.println("Changes were successfully applied to Google Play");
+        if (cannotBeSentForReview) {
+            logger.println("- However, it has indicated that these changes need to be manually submitted for review via the Google Play Console");
+        }
     }
 
     /** @return The name of the credential being used. */

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkUploadTask.java
@@ -18,10 +18,8 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import java.io.File;
 import java.io.IOException;
-import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
@@ -33,8 +31,8 @@ import java.util.TreeSet;
 import static hudson.Functions.humanReadableByteSize;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.ApkPublisher.ExpansionFileSet;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.ApkPublisher.RecentChanges;
-import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.DEOBFUSCATION_FILE_TYPE_PROGUARD;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.DEOBFUSCATION_FILE_TYPE_NATIVE_CODE;
+import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.DEOBFUSCATION_FILE_TYPE_PROGUARD;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.OBB_FILE_TYPE_MAIN;
 import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.OBB_FILE_TYPE_PATCH;
 
@@ -181,25 +179,8 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
             trackName, rolloutFraction, uploadedVersionCodes, inAppUpdatePriority, expandedReleaseName, releaseNotes
         );
 
-        // Commit all the changes
-        try {
-            logger.println("Applying changes to Google Play...");
-            editService.commit(applicationId, editId).execute();
-        } catch (SocketTimeoutException e) {
-            // The API is quite prone to timing out for no apparent reason,
-            // despite having successfully committed the changes on the backend.
-            // So here we check whether the files uploaded were actually committed
-            logger.println(String.format("- An error occurred while applying changes: %s", e));
-            logger.println("- Checking whether the changes have been applied anyway...\n");
-            if (!wereAppFilesUploaded(uploadedVersionCodes)) {
-                logger.println("The files that were uploaded were not found on Google Play");
-                logger.println("- No changes have been applied to the Google Play account");
-                return false;
-            }
-        }
-
-        // If committing didn't throw an exception, everything worked fine
-        logger.println("Changes were successfully applied to Google Play");
+        // Commit the changes, which will throw an exception if there is a problem
+        commit();
         return true;
     }
 
@@ -342,33 +323,6 @@ class ApkUploadTask extends TrackPublisherTask<Boolean> {
         }
 
         return response;
-    }
-
-    /**
-     * Starts a new API session and determines whether a list of version codes were successfully uploaded.
-     *
-     * @param uploadedVersionCodes The list to be checked for existence.
-     * @return {@code true} if the version codes in the list were found to now exist on Google Play.
-     */
-    private boolean wereAppFilesUploaded(Collection<Long> uploadedVersionCodes) throws IOException {
-        // Last edit is finished; create a new one to get the current state
-        createEdit(applicationId);
-
-        // Get the current list of version codes from Google Play
-        List<Long> currentVersionCodes = new ArrayList<>();
-        List<Apk> currentApks = editService.apks().list(applicationId, editId).execute().getApks();
-        if (currentApks == null) currentApks = Collections.emptyList();
-        for (Apk apk : currentApks) {
-            currentVersionCodes.add(Long.valueOf(apk.getVersionCode()));
-        }
-        List<Bundle> currentBundles = editService.bundles().list(applicationId, editId).execute().getBundles();
-        if (currentBundles == null) currentBundles = Collections.emptyList();
-        for (Bundle bundle : currentBundles) {
-            currentVersionCodes.add(Long.valueOf(bundle.getVersionCode()));
-        }
-
-        // The upload succeeded if the current list of version codes intersects with the list we tried to upload
-        return uploadedVersionCodes.removeAll(currentVersionCodes);
     }
 
     /** @return The path to the given file, relative to the build workspace. */

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackAssignmentTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackAssignmentTask.java
@@ -8,7 +8,6 @@ import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import hudson.model.TaskListener;
 
 import java.io.IOException;
-import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -94,18 +93,8 @@ class TrackAssignmentTask extends TrackPublisherTask<Boolean> {
         // Assign the version codes to the configured track
         assignAppFilesToTrack(trackName, rolloutFraction, versionCodes, inAppUpdatePriority, releaseName, releaseNotes);
 
-        // Commit the changes
-        try {
-            logger.println("Applying changes to Google Play...");
-            editService.commit(applicationId, editId).execute();
-        } catch (SocketTimeoutException e) {
-            // TODO: Check, in a new session, whether the given version codes are now in the desired track
-            logger.println(String.format("- An error occurred while applying changes: %s", e));
-            return false;
-        }
-
-        // If committing didn't throw an exception, everything worked fine
-        logger.println("Changes were successfully applied to Google Play");
+        // Commit the changes, which will throw an exception if there is a problem
+        commit();
         return true;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackPublisherTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackPublisherTask.java
@@ -17,7 +17,6 @@ import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.PERCENT
 
 abstract class TrackPublisherTask<V> extends AbstractPublisherTask<V> {
 
-    protected final String applicationId;
     protected String trackName;
     protected final String releaseName;
     protected final double rolloutFraction;
@@ -25,8 +24,7 @@ abstract class TrackPublisherTask<V> extends AbstractPublisherTask<V> {
 
     TrackPublisherTask(TaskListener listener, GoogleRobotCredentials credentials, String applicationId,
                        String trackName, String releaseName, double rolloutPercentage, Integer inAppUpdatePriority) {
-        super(listener, credentials);
-        this.applicationId = applicationId;
+        super(listener, credentials, applicationId);
         this.trackName = trackName;
         this.releaseName = releaseName;
         this.rolloutFraction = rolloutPercentage / 100d;

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
@@ -989,7 +989,7 @@ public class ApkPublisherTest {
                         new FakePutApkResponse().success(42, "the:sha"))
                 .withResponse("/edits/the-edit-id/tracks/" + trackName,
                         new FakeAssignTrackResponse().success(trackName, 42))
-                .withResponse("/edits/the-edit-id:commit",
+                .withResponse("/edits/the-edit-id:commit?changesNotSentForReview=false",
                         new FakeCommitResponse().success())
         ;
     }
@@ -1022,7 +1022,7 @@ public class ApkPublisherTest {
                         new FakePutBundleResponse().success(43, "the:sha"))
                 .withResponse("/edits/the-edit-id/tracks/production",
                         new FakeAssignTrackResponse().success("production", 43))
-                .withResponse("/edits/the-edit-id:commit",
+                .withResponse("/edits/the-edit-id:commit?changesNotSentForReview=false",
                         new FakeCommitResponse().success())
         ;
     }

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilderTest.java
@@ -616,7 +616,7 @@ public class ReleaseTrackAssignmentBuilderTest {
                         new FakeListBundlesResponse().setEmptyBundles())
                 .withResponse("/edits/the-edit-id/tracks/production",
                         new FakeAssignTrackResponse().success("production", 42))
-                .withResponse("/edits/the-edit-id:commit",
+                .withResponse("/edits/the-edit-id:commit?changesNotSentForReview=false",
                         new FakeCommitResponse().success())
         ;
 
@@ -665,7 +665,7 @@ public class ReleaseTrackAssignmentBuilderTest {
                     ))
             .withResponse("/edits/the-edit-id/tracks/" + trackName,
                     new FakeAssignTrackResponse().success(trackName, 42))
-            .withResponse("/edits/the-edit-id:commit",
+            .withResponse("/edits/the-edit-id:commit?changesNotSentForReview=false",
                     new FakeCommitResponse().success())
         ;
     }

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/responses/FakeHttpResponse.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/responses/FakeHttpResponse.java
@@ -4,12 +4,13 @@ import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.Json;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestUtilImpl;
+
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
-import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestUtilImpl;
 
 @SuppressWarnings("unchecked")
 public class FakeHttpResponse<T extends FakeHttpResponse<? extends T>>
@@ -56,7 +57,7 @@ public class FakeHttpResponse<T extends FakeHttpResponse<? extends T>>
 
     public T setError(int code, String error) {
         setStatusCode(code);
-        setContent("{\"error\": \"" + error + "\"}");
+        setContent(String.format("{\"error\":{\"code\":%d,\"message\":\"%s\"}}", code, error));
         return (T) this;
     }
 


### PR DESCRIPTION
**Ticket:**
[JENKINS-65815](https://issues.jenkins.io/browse/JENKINS-65815)

**Description:**
We now automatically set the new(ish) [`changesNotSentForReview`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit) flag as appropriate when committing changes to Google Play (i.e. `false` to begin with, and then retry with `true` if Google Play complains).

Without this, users who have had changes rejected with this message from Google Play currently aren't able to upload changes with the plugin:
> Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI.

**Testing done:**
Updated tests, and added a new automated test for this scenario.