### PR TITLE
[JENKINS-65815] Handle changesNotSentForReview flag (simple version)

### DIFF
--- a/README.md
+++ b/README.md
@@ -344,8 +344,6 @@ In these cases you can try running your build again, or wait a few hours before 
 
 Please also consider [contacting Google Play Developer Support][gp-support-form] to help make them aware that people use the Google Play API, and that it should preferably work in a reliable manner.
 
-This plugin already recognises some temporary Google Play API server problems and works around them; more workarounds may be added in future, e.g. automatically retrying when a generic server error is encountered.
-
 ### Unable to retrieve an access token with the provided credentials
 If you see this error message, look further down the error log to see what is causing it. Below are a couple of common causes:
 

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/InternalAppSharingUploadTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/InternalAppSharingUploadTask.java
@@ -24,7 +24,7 @@ public class InternalAppSharingUploadTask extends AbstractPublisherTask<Boolean>
         TaskListener listener, GoogleRobotCredentials credentials,
         String applicationId, FilePath workspace, UploadFile appFile
     ) {
-        super(listener, credentials);
+        super(listener, credentials, applicationId);
         this.applicationId = applicationId;
         this.workspace = workspace;
         this.appFile = appFile;

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackAssignmentTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackAssignmentTask.java
@@ -8,7 +8,6 @@ import com.google.jenkins.plugins.credentials.oauth.GoogleRobotCredentials;
 import hudson.model.TaskListener;
 
 import java.io.IOException;
-import java.net.SocketTimeoutException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -94,18 +93,8 @@ class TrackAssignmentTask extends TrackPublisherTask<Boolean> {
         // Assign the version codes to the configured track
         assignAppFilesToTrack(trackName, rolloutFraction, versionCodes, inAppUpdatePriority, releaseName, releaseNotes);
 
-        // Commit the changes
-        try {
-            logger.println("Applying changes to Google Play...");
-            editService.commit(applicationId, editId).execute();
-        } catch (SocketTimeoutException e) {
-            // TODO: Check, in a new session, whether the given version codes are now in the desired track
-            logger.println(String.format("- An error occurred while applying changes: %s", e));
-            return false;
-        }
-
-        // If committing didn't throw an exception, everything worked fine
-        logger.println("Changes were successfully applied to Google Play");
+        // Commit the changes, which will throw an exception if there is a problem
+        commit();
         return true;
     }
 

--- a/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackPublisherTask.java
+++ b/src/main/java/org/jenkinsci/plugins/googleplayandroidpublisher/TrackPublisherTask.java
@@ -17,7 +17,6 @@ import static org.jenkinsci.plugins.googleplayandroidpublisher.Constants.PERCENT
 
 abstract class TrackPublisherTask<V> extends AbstractPublisherTask<V> {
 
-    protected final String applicationId;
     protected String trackName;
     protected final String releaseName;
     protected final double rolloutFraction;
@@ -25,8 +24,7 @@ abstract class TrackPublisherTask<V> extends AbstractPublisherTask<V> {
 
     TrackPublisherTask(TaskListener listener, GoogleRobotCredentials credentials, String applicationId,
                        String trackName, String releaseName, double rolloutPercentage, Integer inAppUpdatePriority) {
-        super(listener, credentials);
-        this.applicationId = applicationId;
+        super(listener, credentials, applicationId);
         this.trackName = trackName;
         this.releaseName = releaseName;
         this.rolloutFraction = rolloutPercentage / 100d;

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
@@ -18,6 +18,7 @@ import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestHttpTranspo
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestUtilImpl;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeAssignTrackResponse;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeCommitResponse;
+import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeHttpResponse;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeInternalAppSharingArtifactResponse;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeListApksResponse;
 import org.jenkinsci.plugins.googleplayandroidpublisher.internal.responses.FakeListBundlesResponse;
@@ -460,6 +461,28 @@ public class ApkPublisherTest {
     }
 
     @Test
+    public void uploadingApkWithReviewWarningSucceeds() throws Exception {
+        // Given a job, whose publisher has a credential, track name, and rollout percentage, but no other configuration
+        FreeStyleProject p = j.createFreeStyleProject();
+        ApkPublisher publisher = new ApkPublisher();
+        publisher.setGoogleCredentialsId("test-credentials");
+        publisher.setTrackName("production");
+        publisher.setRolloutPercentage("100");
+        p.getPublishersList().add(publisher);
+
+        // And the prerequisites are in place, but automated review submission will be rejected
+        setUpCredentials("test-credentials");
+        setUpTransportForApk("production", true, false);
+        setUpApkFile(p);
+
+        // When a build occurs, it should succeed, and indicate that it needs to be manually submitted for review
+        assertResultWithLogLines(j, p, Result.SUCCESS,
+            "Changes were successfully applied to Google Play",
+            "- However, it has indicated that these changes need to be manually submitted for review"
+        );
+    }
+
+    @Test
     public void uploadingApkWithPipelineWithoutTrackNameFails() throws Exception {
         // Given a Pipeline where the track name is not provided
         String stepDefinition = "androidApkUpload googleCredentialsId: 'test-credentials'";
@@ -540,7 +563,7 @@ public class ApkPublisherTest {
         // And the prerequisites are in place
         // But the initial 'tracks' response won't include the track, as it doesn't yet have any releases
         setUpCredentials("test-credentials");
-        setUpTransportForApk("dogfood", false);
+        setUpTransportForApk("dogfood", false, true);
         setUpApkFile(p);
 
         // When a build occurs
@@ -949,7 +972,7 @@ public class ApkPublisherTest {
     @WithoutJenkins
     public void responsesCanBeSerialized() throws IOException, ClassNotFoundException {
         transport.withResponse("/edits",
-                new FakePostEditsResponse().setError(400, "error"));
+                new FakePostEditsResponse().setError(400, "error msg"));
 
         ByteArrayOutputStream bos = new ByteArrayOutputStream();
         ObjectOutputStream oos = new ObjectOutputStream(bos);
@@ -969,7 +992,7 @@ public class ApkPublisherTest {
         TestHttpTransport.SimpleResponse response = deserializedTransport.responses.get("/edits");
         assertNotNull(response);
         assertThat(response.statusCode, equalTo(400));
-        assertEquals(response.jsonContent, "{\"error\": \"error\"}");
+        assertEquals(response.jsonContent, "{\"error\":{\"code\":400,\"message\":\"error msg\"}}");
     }
 
     @Test
@@ -1008,10 +1031,10 @@ public class ApkPublisherTest {
     }
 
     private void setUpTransportForApk(String trackName) {
-        setUpTransportForApk(trackName, true);
+        setUpTransportForApk(trackName, true, true);
     }
 
-    private void setUpTransportForApk(String trackName, boolean includeTrackInList) {
+    private void setUpTransportForApk(String trackName, boolean includeTrackInList, boolean allowReviewSubmission) {
         transport
                 .withResponse("/edits",
                         new FakePostEditsResponse().setEditId("the-edit-id"))
@@ -1037,9 +1060,19 @@ public class ApkPublisherTest {
                         new FakePutApkResponse().success(42, "the:sha"))
                 .withResponse("/edits/the-edit-id/tracks/" + trackName,
                         new FakeAssignTrackResponse().success(trackName, 42))
-                .withResponse("/edits/the-edit-id:commit?changesNotSentForReview=false",
-                        new FakeCommitResponse().success())
         ;
+        if (allowReviewSubmission) {
+            transport.withResponse("/edits/the-edit-id:commit?changesNotSentForReview=false",
+                    new FakeCommitResponse().success());
+        } else {
+            transport
+                    .withResponse("/edits/the-edit-id:commit?changesNotSentForReview=false",
+                        FakeHttpResponse.forError(400, "Changes cannot be sent for review automatically. " +
+                                "Please set the query parameter changesNotSentForReview to true. Once committed, the " +
+                                "changes in this edit can be sent for review from the Google Play Console UI."))
+                    .withResponse("/edits/the-edit-id:commit?changesNotSentForReview=true",
+                            new FakeCommitResponse().success());
+        }
     }
 
     private void setUpTransportForInternalApkSharing() {

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ApkPublisherTest.java
@@ -1037,7 +1037,7 @@ public class ApkPublisherTest {
                         new FakePutApkResponse().success(42, "the:sha"))
                 .withResponse("/edits/the-edit-id/tracks/" + trackName,
                         new FakeAssignTrackResponse().success(trackName, 42))
-                .withResponse("/edits/the-edit-id:commit",
+                .withResponse("/edits/the-edit-id:commit?changesNotSentForReview=false",
                         new FakeCommitResponse().success())
         ;
     }
@@ -1079,7 +1079,7 @@ public class ApkPublisherTest {
                         new FakePutBundleResponse().success(43, "the:sha"))
                 .withResponse("/edits/the-edit-id/tracks/production",
                         new FakeAssignTrackResponse().success("production", 43))
-                .withResponse("/edits/the-edit-id:commit",
+                .withResponse("/edits/the-edit-id:commit?changesNotSentForReview=false",
                         new FakeCommitResponse().success())
         ;
     }

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilderTest.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/ReleaseTrackAssignmentBuilderTest.java
@@ -616,7 +616,7 @@ public class ReleaseTrackAssignmentBuilderTest {
                         new FakeListBundlesResponse().setEmptyBundles())
                 .withResponse("/edits/the-edit-id/tracks/production",
                         new FakeAssignTrackResponse().success("production", 42))
-                .withResponse("/edits/the-edit-id:commit",
+                .withResponse("/edits/the-edit-id:commit?changesNotSentForReview=false",
                         new FakeCommitResponse().success())
         ;
 
@@ -665,7 +665,7 @@ public class ReleaseTrackAssignmentBuilderTest {
                     ))
             .withResponse("/edits/the-edit-id/tracks/" + trackName,
                     new FakeAssignTrackResponse().success(trackName, 42))
-            .withResponse("/edits/the-edit-id:commit",
+            .withResponse("/edits/the-edit-id:commit?changesNotSentForReview=false",
                     new FakeCommitResponse().success())
         ;
     }

--- a/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/responses/FakeHttpResponse.java
+++ b/src/test/java/org/jenkinsci/plugins/googleplayandroidpublisher/internal/responses/FakeHttpResponse.java
@@ -4,12 +4,13 @@ import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.Json;
 import com.google.api.client.json.jackson2.JacksonFactory;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
+import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestUtilImpl;
+
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
-import javax.annotation.Nullable;
-import org.jenkinsci.plugins.googleplayandroidpublisher.internal.TestUtilImpl;
 
 @SuppressWarnings("unchecked")
 public class FakeHttpResponse<T extends FakeHttpResponse<? extends T>>
@@ -56,7 +57,7 @@ public class FakeHttpResponse<T extends FakeHttpResponse<? extends T>>
 
     public T setError(int code, String error) {
         setStatusCode(code);
-        setContent("{\"error\": \"" + error + "\"}");
+        setContent(String.format("{\"error\":{\"code\":%d,\"message\":\"%s\"}}", code, error));
         return (T) this;
     }
 


### PR DESCRIPTION
**Ticket:**
[JENKINS-65815](https://issues.jenkins.io/browse/JENKINS-65815)

**Description:**
We now automatically set the new(ish) [`changesNotSentForReview`](https://developers.google.com/android-publisher/api-ref/rest/v3/edits/commit) flag as appropriate when committing changes to Google Play (i.e. `false` to begin with, and then retry with `true` if Google Play complains).

Without this, users who have had changes rejected with this message from Google Play currently aren't able to upload changes with the plugin:
> Changes cannot be sent for review automatically. Please set the query parameter changesNotSentForReview to true. Once committed, the changes in this edit can be sent for review from the Google Play Console UI.

[Since #43 can't be merged until the google-oauth-plugin is updated, this PR just sets the `changesNotSentForReview` URL parameter using the generic setter that the SDK provides.]

**Testing done:**
Updated tests, and added a new automated test for this scenario.